### PR TITLE
Fix: fix LMS_ROOT_URL

### DIFF
--- a/lms/djangoapps/philu_overrides/courseware/views/views.py
+++ b/lms/djangoapps/philu_overrides/courseware/views/views.py
@@ -70,7 +70,7 @@ def generate_user_cert(request, course_id):
         # mark the certificate with "error" status, so it can be re-run
         # with a management command.  From the user's perspective,
         # it will appear that the certificate task was submitted successfully.
-        base_url = settings.LMS_ROOT_URL[:-3]
+        base_url = settings.LMS_ROOT_URL
         MandrillClient().send_mail(
             MandrillClient.COURSE_COMPLETION_TEMPLATE,
             student.email,

--- a/openedx/core/djangoapps/timed_notification/core.py
+++ b/openedx/core/djangoapps/timed_notification/core.py
@@ -93,5 +93,5 @@ def send_course_notification_email(course, template_name, context, to_list=None)
 
 def get_course_link(course_id):
     course_link = reverse("about_course", args=[course_id])
-    base_url = settings.LMS_ROOT_URL[:-3]
+    base_url = settings.LMS_ROOT_URL
     return base_url + course_link


### PR DESCRIPTION
This should fix the missing `org` at the end of **certificate_url**