### PR TITLE
remove recurring polling logs filter

### DIFF
--- a/openedx/core/lib/log_utils.py
+++ b/openedx/core/lib/log_utils.py
@@ -38,6 +38,15 @@ def audit_log(name, **kwargs):
 
 class RemoveRecurringPollingLogsFilter(logging.Filter):
     def filter(self, record):
+        """
+        :param record: LogRecord
+        :return: Boolean (True/False)
+        # True, if you want to show the log
+        # else False
+        """
+
+        # polling is creating numerous logs per second for requests module connection
+        # to avoid that recurring logs we are hiding that logs
         if record.name == 'requests.packages.urllib3.connectionpool':
             return False
         return True

--- a/openedx/core/lib/log_utils.py
+++ b/openedx/core/lib/log_utils.py
@@ -34,3 +34,10 @@ def audit_log(name, **kwargs):
     message = u'{name}: {payload}'.format(name=name, payload=payload)
 
     log.info(message)
+
+
+class RemoveRecurringPollingLogsFilter(logging.Filter):
+    def filter(self, record):
+        if record.name == 'requests.packages.urllib3.connectionpool':
+            return False
+        return True

--- a/openedx/core/lib/logsettings.py
+++ b/openedx/core/lib/logsettings.py
@@ -73,12 +73,16 @@ def get_logger_config(log_dir,
         'filters': {
             'require_debug_false': {
                 '()': 'django.utils.log.RequireDebugFalse',
+            },
+            'remove_recurring_polling_logs': {
+                '()': 'openedx.core.lib.log_utils.RemoveRecurringPollingLogsFilter'
             }
         },
         'handlers': {
             'console': {
                 'level': console_loglevel,
                 'class': 'logging.StreamHandler',
+                'filters': ['remove_recurring_polling_logs'],
                 'formatter': 'standard',
                 'stream': sys.stderr,
             },


### PR DESCRIPTION
Polling is create that logging numerous times per second which is quite headache to track the logs.


`2018-07-02 09:02:22,719 INFO 28449 [requests.packages.urllib3.connectionpool] connectionpool.py:203 - Starting new HTTP connection (1): local.philanthropyu.org`
