### PR TITLE
LP-1022 : Ability to create a private course (missing requirement)

### DIFF
--- a/lms/djangoapps/philu_overrides/views.py
+++ b/lms/djangoapps/philu_overrides/views.py
@@ -43,7 +43,7 @@ from third_party_auth import pipeline, provider
 from util.json_request import JsonResponse
 from edxmako.shortcuts import marketing_link
 from openedx.core.djangoapps.external_auth.models import ExternalAuthMap
-from student.models import (LoginFailures, PasswordHistory)
+from student.models import (LoginFailures, PasswordHistory, CourseEnrollment)
 from ratelimitbackend.exceptions import RateLimitException
 from django.contrib.auth import authenticate, login
 import analytics
@@ -547,6 +547,9 @@ def course_about(request, course_id):
 
         staff_access = bool(has_access(request.user, 'staff', course))
         studio_url = get_studio_url(course, 'settings/details')
+
+        if not staff_access and course.invitation_only and not CourseEnrollment.is_enrolled(request.user, course.id) :
+            raise Http404("Course not accessible: {}.".format(unicode(course.id)))
 
         # Note: this is a flow for payment for course registration, not the Verified Certificate flow.
         # in_cart = False


### PR DESCRIPTION
The course card will be created but will not be visible. It will be visible only when a learner is enrolled into the course; then the learner would be able to see the course on the catalog and on their dashboard (in ‘Enrolled' tab), and also in ’Past courses' tab when the private course ends. But anyone other than the invited learner will not be able to view the card.