### PR TITLE
LP-1216 Allowed accented characters in fields not being accepted

### DIFF
--- a/lms/djangoapps/onboarding/models.py
+++ b/lms/djangoapps/onboarding/models.py
@@ -510,7 +510,7 @@ class UserExtendedProfile(TimeStampedModel):
             if _function_area_field in selected_values:
                 _updated_value_about_philanthropy = self.HEAR_ABOUT_PHILANTHROPY_LABELS.get(function_area_field)
             if _function_area_field == 'hear_about_other' and _other_field:
-                _updated_value_about_philanthropy_other = str(_other_field[0])
+                _updated_value_about_philanthropy_other = _other_field[0]
 
         self.__setattr__('hear_about_philanthropy', _updated_value_about_philanthropy)
         self.__setattr__('hear_about_philanthropy_other', _updated_value_about_philanthropy_other)

--- a/lms/djangoapps/philu_overrides/user_api/views.py
+++ b/lms/djangoapps/philu_overrides/user_api/views.py
@@ -208,7 +208,10 @@ def create_account_with_params_custom(request, params, is_alquity_user):
         not eamap.external_domain.startswith(openedx.core.djangoapps.external_auth.views.SHIBBOLETH_DOMAIN_PREFIX)
     )
 
-    params['name'] = "{} {}".format(params.get('first_name'), params.get('last_name'))
+    params['name'] = "{} {}".format(
+        params.get('first_name', '').encode('utf-8'), params.get('last_name', '').encode('utf-8')
+    )
+
     form = AccountCreationForm(
         data=params,
         extra_fields=extra_fields,


### PR DESCRIPTION
encoded first_name and last_name strings while being concatenated for the model UserProfile's name field.

removed string typecast on the other field in the UserExtendedProfile Model