### PR TITLE
added target _blank into team profile view

### DIFF
--- a/lms/djangoapps/teams/static/teams/templates/team-member.underscore
+++ b/lms/djangoapps/teams/static/teams/templates/team-member.underscore
@@ -1,6 +1,6 @@
 <li>
   <span class="team-member">
-    <a class="member-profile" href="<%= memberProfileUrl %>">
+    <a class="member-profile" href="<%= memberProfileUrl %>" target="_blank">
       <p class="tooltip-custom"><%= username %></p>
       <img class="image-url" src="<%= imageUrl %>" alt="profile page"/>
     </a>


### PR DESCRIPTION
edx-platform/lms/djangoapps/teams/static/teams/templates/team-member.underscore:3
Change reason because we cant take backbone files to philu-edx-theme and path isnt resolved if we put just the underscore files in the theme