### PR TITLE
Test Cases for Philu Commands

### DIFF
--- a/common/djangoapps/philu_commands/management/commands/tests/test_create_certificates_image_command.py
+++ b/common/djangoapps/philu_commands/management/commands/tests/test_create_certificates_image_command.py
@@ -1,0 +1,54 @@
+from __future__ import unicode_literals
+
+import mock
+from certificates.tests.factories import GeneratedCertificateFactory
+from django.core.management import call_command
+from django.db.models.signals import post_save
+from factory.django import mute_signals
+from lms.djangoapps.onboarding.tests.factories import UserFactory
+from student.tests.factories import CourseEnrollmentFactory
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory
+
+
+class CreateCertificateImage(SharedModuleStoreTestCase):
+    """
+        Tests for `create_certificates_image` command.
+    """
+
+    @mute_signals(post_save)
+    def setUp(self):
+        super(CreateCertificateImage, self).setUp()
+        self.user = UserFactory()
+        self.course = CourseFactory()
+        self.course.certificates_display_behavior = "early_with_info"
+
+    @mock.patch('openedx.features.student_certificates.tasks.task_create_certificate_img_and_upload_to_s3.delay')
+    def test_command(self, mock_func):
+        certificate_uuid = self._create_certificate('honor')
+        call_command('create_certificates_image')
+        mock_func.assert_called_once_with(verify_uuid=certificate_uuid)
+
+    @mock.patch('openedx.features.student_certificates.tasks.task_create_certificate_img_and_upload_to_s3.delay')
+    def test_command_with_date_argument(self, mock_func):
+        certificate_uuid = self._create_certificate('honor')
+        call_command('create_certificates_image', '--after=30/6/2019')
+        mock_func.assert_called_once_with(verify_uuid=certificate_uuid)
+
+    @mock.patch('openedx.features.student_certificates.tasks.task_create_certificate_img_and_upload_to_s3.delay')
+    def test_command_with_uuid_argument(self, mock_func):
+        certificate_uuid = self._create_certificate('honor')
+        call_command('create_certificates_image', '--uuid={}'.format(certificate_uuid))
+        mock_func.assert_called_once_with(verify_uuid=certificate_uuid)
+
+    def _create_certificate(self, enrollment_mode):
+        """Simulate that the user has a generated certificate. """
+        CourseEnrollmentFactory.create(user=self.user, course_id=self.course.id, mode=enrollment_mode)
+        certificate = GeneratedCertificateFactory(
+            user=self.user,
+            course_id=self.course.id,
+            mode=enrollment_mode,
+            status="downloadable",
+            grade=0.98,
+        )
+        return certificate.verify_uuid

--- a/common/djangoapps/philu_commands/management/commands/tests/test_mailchimp_commands.py
+++ b/common/djangoapps/philu_commands/management/commands/tests/test_mailchimp_commands.py
@@ -9,11 +9,8 @@ from django.core.management import call_command
 from django.db.models.signals import post_save
 from django.test import TestCase
 from factory.django import mute_signals
-from lms.djangoapps.certificates import api as certificate_api
-from lms.djangoapps.onboarding.models import FocusArea, OrgSector
 from lms.djangoapps.onboarding.tests.factories import OrganizationFactory, UserFactory
-from mailchimp_pipeline.helpers import get_enrollements_course_short_ids, get_user_active_enrollements
-from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+from philu_commands.management.commands.sync_users_with_mailchimp import Command
 
 log = logging.getLogger(__name__)
 logging.disable(logging.NOTSET)
@@ -40,96 +37,70 @@ class MailChimpUser(TestCase):
         self.user.extended_profile.save()
 
     @mock.patch('mailchimp_pipeline.client.ChimpClient.delete_user_from_list')
-    def test_delete_users_from_mailchimp(self, mock_func):
+    def test_delete_users_from_mailchimp_command(self, mock_func):
+        """
+        This test checks the delete_user_from_mailchimp command.
+        :param mock_func: Mocked Function to be tested.
+        """
         call_command('delete_users_from_mailchimp')
         mock_func.assert_called_once_with(settings.MAILCHIMP_LEARNERS_LIST_ID, self.user.email)
 
     @mock.patch('mailchimp_pipeline.client.ChimpClient.add_list_members_in_batch')
-    @mock.patch('django.db.connection')
+    @mock.patch('philu_commands.management.commands.sync_users_with_mailchimp.connection')
     def test_sync_users_with_mailchimp_command(self, mocked_connection, mock_func):
+        """
+        This test checks the sync_user_with_mailchimp_command for with accurate data and check whether command pass the
+        data to mailchimp accurately or not.
+        :param mocked_connection: Mocked connection to handle the Database Cursor.
+        :param mock_func: Mocked function which is responsible for sending data to mailchimp this function is to be
+                            tested.
+        """
         users = list(User.objects.all())
-        users_data = self.get_users_data_to_send(users)
+        users_data = Command().get_users_data_to_send(users)
         call_command('sync_users_with_mailchimp')
         mock_func.assert_called_once_with(settings.MAILCHIMP_LEARNERS_LIST_ID, {"members": users_data})
 
     @mock.patch('lms.djangoapps.certificates.api.get_certificates_for_user')
     @mock.patch('mailchimp_pipeline.client.ChimpClient.add_list_members_in_batch')
-    @mock.patch('django.db.connection')
+    @mock.patch('philu_commands.management.commands.sync_users_with_mailchimp.connection')
     def test_sync_users_with_mailchimp_command_for_cert_exception(self, mocked_connection, mock_func,
                                                                   mocked_get_user_cert_func):
+        """
+        This test is responsible for creating Exception while getting certificate data for user. This test covers the
+        except part of User Certificate Gathering.
+        :param mocked_connection: Mocked connection to handle the Database Cursor.
+        :param mock_func: Mocked function which is responsible for sending data to mailchimp this function is to be
+                            tested.
+        :param mocked_get_user_cert_func: Mocked function to Raise Exception in command.
+        :return:
+        """
         mocked_get_user_cert_func.side_effect = Exception
         users = list(User.objects.all())
-        users_data = self.get_users_data_to_send(users)
+        users_data = Command().get_users_data_to_send(users)
         call_command('sync_users_with_mailchimp')
         mock_func.assert_called_once_with(settings.MAILCHIMP_LEARNERS_LIST_ID, {"members": users_data})
         self.assertRaises(Exception)
 
-    @mock.patch('django.db.connection')
+    @mock.patch('philu_commands.management.commands.sync_users_with_mailchimp.connection')
     def test_sync_users_with_mailchimp_command_for_exception(self, mocked_connection):
-        users = list(User.objects.all())
-        users_data = self.get_users_data_to_send(users)
+        """
+        This test case is responsible for generating exception in the main try and except block in handle function of
+        command and check the except block. We have not mocked the mailchimp function so in testing environment whenever
+        we will call mailchimp function it will return exception.
+        :param mocked_connection: Mocked connection to handle the Database Cursor.
+        """
         call_command('sync_users_with_mailchimp')
         self.assertRaises(Exception)
 
     @mock.patch('philu_commands.management.commands.sync_users_with_mailchimp.get_user_active_enrollements')
-    @mock.patch('django.db.connection')
+    @mock.patch('philu_commands.management.commands.sync_users_with_mailchimp.connection')
     def test_sync_users_with_mailchimp_command_for_user_exception(self, mocked_connection, mocked_user_enrollment_func):
+        """
+        This test is responsible for creating Exception while getting data for user. This test covers the
+        except part of User Data Gathering.
+        :param mocked_connection: Mocked connection to handle the Database Cursor.
+        :param mocked_user_enrollment_func: Mocked function to Raise Exception in command.
+        """
         mocked_user_enrollment_func.side_effect = Exception
-        users = list(User.objects.all())
-        users_data = self.get_users_data_to_send(users)
         call_command('sync_users_with_mailchimp')
         self.assertRaises(Exception)
-
-    def get_users_data_to_send(self, users):
-        users_set = []
-
-        focus_areas = FocusArea.get_map()
-        org_sectors = OrgSector.get_map()
-
-        for user in users:
-            profile = user.profile
-            extended_profile = user.extended_profile
-
-            org_type = ""
-            if extended_profile.organization and extended_profile.organization.org_type:
-                org_type = org_sectors.get(extended_profile.organization.org_type, '')
-
-            all_certs = []
-            try:
-                all_certs = certificate_api.get_certificates_for_user(user.username)
-            except Exception as ex:
-                log.exception(str(ex.args))
-
-            completed_course_keys = [cert.get('course_key', '') for cert in all_certs
-                                     if certificate_api.is_passing_status(cert['status'])]
-            completed_courses = CourseOverview.objects.filter(id__in=completed_course_keys)
-
-            try:
-                user_json = {
-                    "email_address": user.email,
-                    "status_if_new": "subscribed",
-                    "merge_fields": {
-                        "FULLNAME": user.get_full_name(),
-                        "USERNAME": user.username,
-                        "LANG": profile.language if profile.language else "",
-                        "COUNTRY": profile.country.name.format() if profile.country else "",
-                        "CITY": profile.city if profile.city else "",
-                        "DATEREGIS": str(user.date_joined.strftime("%m/%d/%Y")),
-                        "LSOURCE": "",
-                        "COMPLETES": ", ".join([course.display_name for course in completed_courses]),
-                        "ENROLLS": get_user_active_enrollements(user.username),
-                        "ENROLL_IDS": get_enrollements_course_short_ids(user.username),
-                        "ORG": extended_profile.organization.label if extended_profile.organization else "",
-                        "ORGTYPE": org_type,
-                        "WORKAREA": str(focus_areas.get(extended_profile.organization.focus_area, ""))
-                        if extended_profile.organization else "",
-                    }
-                }
-            except Exception as ex:
-                log.info("There was an error for user with email address as {}".format(user.email))
-                log.exception(str(ex.args))
-                continue
-
-            users_set.append(user_json)
-
-        return users_set

--- a/common/djangoapps/philu_commands/management/commands/tests/test_mailchimp_commands.py
+++ b/common/djangoapps/philu_commands/management/commands/tests/test_mailchimp_commands.py
@@ -1,0 +1,135 @@
+from __future__ import unicode_literals
+
+import logging
+
+import mock
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.core.management import call_command
+from django.db.models.signals import post_save
+from django.test import TestCase
+from factory.django import mute_signals
+from lms.djangoapps.certificates import api as certificate_api
+from lms.djangoapps.onboarding.models import FocusArea, OrgSector
+from lms.djangoapps.onboarding.tests.factories import OrganizationFactory, UserFactory
+from mailchimp_pipeline.helpers import get_enrollements_course_short_ids, get_user_active_enrollements
+from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+
+log = logging.getLogger(__name__)
+logging.disable(logging.NOTSET)
+log.setLevel(logging.DEBUG)
+
+
+class MailChimpUser(TestCase):
+    """
+        Tests for both `sync_users_with_mailchimp` and `delete_users_from_mailchimp` command.
+    """
+
+    @mute_signals(post_save)
+    def setUp(self):
+        super(MailChimpUser, self).setUp()
+        self.user = UserFactory.create(
+            username="test",
+            password="test123",
+            email="test@example.com"
+        )
+        org = OrganizationFactory()
+        org.org_type = "New"
+        org.save()
+        self.user.extended_profile.organization = org
+        self.user.extended_profile.save()
+
+    @mock.patch('mailchimp_pipeline.client.ChimpClient.delete_user_from_list')
+    def test_delete_users_from_mailchimp(self, mock_func):
+        call_command('delete_users_from_mailchimp')
+        mock_func.assert_called_once_with(settings.MAILCHIMP_LEARNERS_LIST_ID, self.user.email)
+
+    @mock.patch('mailchimp_pipeline.client.ChimpClient.add_list_members_in_batch')
+    @mock.patch('django.db.connection')
+    def test_sync_users_with_mailchimp_command(self, mocked_connection, mock_func):
+        users = list(User.objects.all())
+        users_data = self.get_users_data_to_send(users)
+        call_command('sync_users_with_mailchimp')
+        mock_func.assert_called_once_with(settings.MAILCHIMP_LEARNERS_LIST_ID, {"members": users_data})
+
+    @mock.patch('lms.djangoapps.certificates.api.get_certificates_for_user')
+    @mock.patch('mailchimp_pipeline.client.ChimpClient.add_list_members_in_batch')
+    @mock.patch('django.db.connection')
+    def test_sync_users_with_mailchimp_command_for_cert_exception(self, mocked_connection, mock_func,
+                                                                  mocked_get_user_cert_func):
+        mocked_get_user_cert_func.side_effect = Exception
+        users = list(User.objects.all())
+        users_data = self.get_users_data_to_send(users)
+        call_command('sync_users_with_mailchimp')
+        mock_func.assert_called_once_with(settings.MAILCHIMP_LEARNERS_LIST_ID, {"members": users_data})
+        self.assertRaises(Exception)
+
+    @mock.patch('django.db.connection')
+    def test_sync_users_with_mailchimp_command_for_exception(self, mocked_connection):
+        users = list(User.objects.all())
+        users_data = self.get_users_data_to_send(users)
+        call_command('sync_users_with_mailchimp')
+        self.assertRaises(Exception)
+
+    @mock.patch('philu_commands.management.commands.sync_users_with_mailchimp.get_user_active_enrollements')
+    @mock.patch('django.db.connection')
+    def test_sync_users_with_mailchimp_command_for_user_exception(self, mocked_connection, mocked_user_enrollment_func):
+        mocked_user_enrollment_func.side_effect = Exception
+        users = list(User.objects.all())
+        users_data = self.get_users_data_to_send(users)
+        call_command('sync_users_with_mailchimp')
+        self.assertRaises(Exception)
+
+    def get_users_data_to_send(self, users):
+        users_set = []
+
+        focus_areas = FocusArea.get_map()
+        org_sectors = OrgSector.get_map()
+
+        for user in users:
+            profile = user.profile
+            extended_profile = user.extended_profile
+
+            org_type = ""
+            if extended_profile.organization and extended_profile.organization.org_type:
+                org_type = org_sectors.get(extended_profile.organization.org_type, '')
+
+            all_certs = []
+            try:
+                all_certs = certificate_api.get_certificates_for_user(user.username)
+            except Exception as ex:
+                log.exception(str(ex.args))
+
+            completed_course_keys = [cert.get('course_key', '') for cert in all_certs
+                                     if certificate_api.is_passing_status(cert['status'])]
+            completed_courses = CourseOverview.objects.filter(id__in=completed_course_keys)
+
+            try:
+                user_json = {
+                    "email_address": user.email,
+                    "status_if_new": "subscribed",
+                    "merge_fields": {
+                        "FULLNAME": user.get_full_name(),
+                        "USERNAME": user.username,
+                        "LANG": profile.language if profile.language else "",
+                        "COUNTRY": profile.country.name.format() if profile.country else "",
+                        "CITY": profile.city if profile.city else "",
+                        "DATEREGIS": str(user.date_joined.strftime("%m/%d/%Y")),
+                        "LSOURCE": "",
+                        "COMPLETES": ", ".join([course.display_name for course in completed_courses]),
+                        "ENROLLS": get_user_active_enrollements(user.username),
+                        "ENROLL_IDS": get_enrollements_course_short_ids(user.username),
+                        "ORG": extended_profile.organization.label if extended_profile.organization else "",
+                        "ORGTYPE": org_type,
+                        "WORKAREA": str(focus_areas.get(extended_profile.organization.focus_area, ""))
+                        if extended_profile.organization else "",
+                    }
+                }
+            except Exception as ex:
+                log.info("There was an error for user with email address as {}".format(user.email))
+                log.exception(str(ex.args))
+                continue
+
+            users_set.append(user_json)
+
+        return users_set

--- a/common/djangoapps/philu_commands/management/commands/tests/test_sync_users_with_nodebb_command.py
+++ b/common/djangoapps/philu_commands/management/commands/tests/test_sync_users_with_nodebb_command.py
@@ -1,0 +1,103 @@
+from __future__ import unicode_literals
+
+import mock
+from django.core.management import call_command
+from django.db.models.signals import post_save
+from django.test import TestCase
+from factory.django import mute_signals
+from lms.djangoapps.onboarding.helpers import COUNTRIES
+from lms.djangoapps.onboarding.models import UserExtendedProfile
+from lms.djangoapps.onboarding.tests.factories import UserFactory
+
+
+class NodeBBSync(TestCase):
+    """
+        Tests for `create_certificates_image` command.
+    """
+    nodebb_data = {
+        'website': '',
+        'last_name': 'Test',
+        'uid': 2,
+        'first_name': 'Robot1',
+        'country_of_residence': '',
+        'email': 'test@example.com',
+        'username': 'test',
+        'city_of_residence': '',
+        '_key': 'user:10',
+        'country_of_employment': '',
+        'fullname': 'Robot1 Test',
+        'userslug': 'test',
+        'edx_user_id': 2,
+        'language': 'None'
+    }
+
+    @mute_signals(post_save)
+    def setUp(self):
+        super(NodeBBSync, self).setUp()
+        self.user = UserFactory(username="test", email="test@example.com", password="123")
+        self.user_edx_data = self._generate_edx_data()
+
+    @mock.patch('common.lib.nodebb_client.users.ForumUser.all', return_value=[200, []])
+    @mock.patch('common.djangoapps.nodebb.tasks.task_create_user_on_nodebb.delay')
+    @mock.patch('common.djangoapps.nodebb.tasks.task_activate_user_on_nodebb.delay')
+    def test_command_for_user_creation_on_nodebb(self, mocked_task_activate_user_on_nodebb,
+                                                 mocked_task_create_user_on_nodebb,
+                                                 mocked_all_func_nodebb_client_users_module):
+        call_command('sync_users_with_nodebb')
+        mocked_task_create_user_on_nodebb.assert_called_once_with(username=self.user.username,
+                                                                  user_data=self.user_edx_data)
+        mocked_task_activate_user_on_nodebb.assert_called_once_with(username=self.user.username,
+                                                                    active=self.user.is_active)
+
+    @mock.patch('common.djangoapps.nodebb.tasks.task_update_onboarding_surveys_status.delay')
+    @mock.patch('lms.djangoapps.onboarding.models.UserExtendedProfile.unattended_surveys', return_value=[])
+    @mock.patch('common.lib.nodebb_client.users.ForumUser.all', return_value=[200, []])
+    @mock.patch('common.djangoapps.nodebb.tasks.task_create_user_on_nodebb.delay')
+    @mock.patch('common.djangoapps.nodebb.tasks.task_activate_user_on_nodebb.delay')
+    def test_command_for_user_creation_without_attended_surveys_on_nodebb(self, mocked_task_activate_user_on_nodebb,
+                                                                          mocked_task_create_user_on_nodebb,
+                                                                          mocked_all_func_nodebb_client_users_module,
+                                                                          mocked_function_of_model,
+                                                                          mocked_task_update_onboarding_surveys):
+        call_command('sync_users_with_nodebb')
+        mocked_task_create_user_on_nodebb.assert_called_once_with(username=self.user.username,
+                                                                  user_data=self.user_edx_data)
+        mocked_task_activate_user_on_nodebb.assert_called_once_with(username=self.user.username,
+                                                                    active=self.user.is_active)
+        mocked_task_update_onboarding_surveys.assert_called_once_with(username=self.user.username)
+
+    @mock.patch('common.lib.nodebb_client.users.ForumUser.all', return_value=[302, []])
+    def test_command_for_status_code_302(self, mocked_all_func_nodebb_client_users_module):
+        self.assertIsNone(call_command('sync_users_with_nodebb'))
+
+    @mock.patch('common.lib.nodebb_client.users.ForumUser.all', return_value=[200, [nodebb_data]])
+    @mock.patch('common.djangoapps.nodebb.tasks.task_update_user_profile_on_nodebb.delay')
+    def test_command_for_user_update_on_nodebb(self, mocked_task_update_user_profile_on_nodebbb,
+                                               mocked_all_func_nodebb_client_users_module):
+        call_command('sync_users_with_nodebb')
+        mocked_task_update_user_profile_on_nodebbb.assert_called_once_with(username=self.user.username,
+                                                                           profile_data=self.user_edx_data)
+
+    @staticmethod
+    def _generate_edx_data():
+        extended_profile = UserExtendedProfile.objects.all()[0]
+        user = extended_profile.user
+        profile = user.profile
+
+        edx_data = {
+            'edx_user_id': unicode(user.id),
+            'username': user.username,
+            'email': user.email,
+            'first_name': user.first_name,
+            'last_name': user.last_name,
+            'country_of_employment': extended_profile.country_of_employment,
+            'city_of_employment': extended_profile.city_of_employment,
+            'country_of_residence': COUNTRIES.get(profile.country.code),
+            'city_of_residence': profile.city,
+            'birthday': profile.year_of_birth,
+            'language': profile.language,
+            'interests': extended_profile.get_user_selected_interests(),
+            'self_prioritize_areas': extended_profile.get_user_selected_functions()
+        }
+
+        return edx_data

--- a/common/djangoapps/philu_commands/management/commands/tests/update_org_metrics_test_api.py
+++ b/common/djangoapps/philu_commands/management/commands/tests/update_org_metrics_test_api.py
@@ -1,0 +1,169 @@
+# encoding: utf-8
+"""Tests of Management Commands """
+from __future__ import unicode_literals
+
+from datetime import timedelta
+
+from django.contrib.auth.models import User
+from django.core.management import call_command
+from django.test import TestCase
+from lms.djangoapps.onboarding.helpers import get_current_utc_date
+from lms.djangoapps.onboarding.models import OrganizationMetricUpdatePrompt, Organization
+
+
+class OrganizationMetrics(TestCase):
+    """Test Command to update Organization Metrics"""
+
+    def test_update_org_today_metrics(self):
+        user = User(username='usman', email='usman@gmail.com', first_name='usman',
+                    last_name='khan', password='abc123', is_active=True)
+        user.save()
+        org = Organization(label='Home')
+        org.save()
+        today = get_current_utc_date()
+        save_prompt(user, org, today)
+
+        today_result = {
+            "latest_metric_submission": today,
+            "year": False,
+            "year_month": False,
+            "year_three_month": False,
+            "year_six_month": False,
+        }
+
+        call_command('update_org_metric_prompts')
+        today_metrics = OrganizationMetricUpdatePrompt.objects.filter(latest_metric_submission=today).values(
+            "latest_metric_submission", "year", "year_month", "year_three_month", "year_six_month").first()
+        self.assertEqual(today_metrics['year'], False)
+        self.assertEqual(today_metrics['year_month'], False)
+        self.assertEqual(today_metrics['year_three_month'], False)
+        self.assertEqual(today_metrics['year_six_month'], False)
+
+    def test_update_org_year_old_metrics(self):
+        user2 = User(username='muak', email='muak@gmail.com', first_name='usman',
+                     last_name='arshad', password='abc123', is_active=True)
+        user2.save()
+
+        org = Organization(label='Home')
+        org.save()
+
+        today = get_current_utc_date()
+        one_year_old_date = today - timedelta(days=366)
+
+        save_prompt(user2, org, one_year_old_date)
+
+        one_year_old_result = {
+            "latest_metric_submission": one_year_old_date,
+            "year": True,
+            "year_month": False,
+            "year_three_month": False,
+            "year_six_month": False,
+        }
+
+        call_command('update_org_metric_prompts')
+        one_year_old_metrics = OrganizationMetricUpdatePrompt.objects.filter(
+            latest_metric_submission=one_year_old_date).values(
+            "latest_metric_submission", "year", "year_month", "year_three_month", "year_six_month").first()
+        self.assertEqual(one_year_old_metrics['year'], True)
+        self.assertEqual(one_year_old_metrics['year_month'], False)
+        self.assertEqual(one_year_old_metrics['year_three_month'], False)
+        self.assertEqual(one_year_old_metrics['year_six_month'], False)
+
+    def test_update_org_year_three_months_old_metrics(self):
+        user3 = User(username='ali', email='ali@gmail.com', first_name='ali',
+                     last_name='khan', password='abc123', is_active=True)
+        user3.save()
+
+        org = Organization(label='Home')
+        org.save()
+
+        today = get_current_utc_date()
+        one_year_three_months_old_date = today - timedelta(days=466)
+
+        save_prompt(user3, org, one_year_three_months_old_date)
+
+        one_year_three_month_old_result = {
+            "latest_metric_submission": one_year_three_months_old_date,
+            "year": True,
+            "year_month": True,
+            "year_three_month": True,
+            "year_six_month": False,
+        }
+
+        call_command('update_org_metric_prompts')
+        one_year_three_months_old_metrics = OrganizationMetricUpdatePrompt.objects.filter(
+            latest_metric_submission=one_year_three_months_old_date).values(
+            "latest_metric_submission", "year", "year_month", "year_three_month", "year_six_month").first()
+        self.assertEqual(one_year_three_months_old_metrics['year'], True)
+        self.assertEqual(one_year_three_months_old_metrics['year_month'], True)
+        self.assertEqual(one_year_three_months_old_metrics['year_three_month'], True)
+        self.assertEqual(one_year_three_months_old_metrics['year_six_month'], False)
+
+    def test_update_org_year_six_months_old_metrics(self):
+        user4 = User(username='john', email='john@gmail.com', first_name='John',
+                     last_name='wick', password='abc123', is_active=True)
+        user4.save()
+
+        org = Organization(label='Home')
+        org.save()
+
+        today = get_current_utc_date()
+        one_year_six_months_old_date = today - timedelta(days=550)
+
+        save_prompt(user4, org, one_year_six_months_old_date)
+
+        one_year_six_month_old_result = {
+            "latest_metric_submission": one_year_six_months_old_date,
+            "year": True,
+            "year_month": True,
+            "year_three_month": True,
+            "year_six_month": True,
+        }
+
+        call_command('update_org_metric_prompts')
+        one_year_six_months_old_metrics = OrganizationMetricUpdatePrompt.objects.filter(
+            latest_metric_submission=one_year_six_months_old_date).values(
+            "latest_metric_submission", "year", "year_month", "year_three_month", "year_six_month").first()
+        self.assertEqual(one_year_six_months_old_metrics['year'], True)
+        self.assertEqual(one_year_six_months_old_metrics['year_month'], True)
+        self.assertEqual(one_year_six_months_old_metrics['year_three_month'], True)
+        self.assertEqual(one_year_six_months_old_metrics['year_six_month'], True)
+
+
+def save_prompt(user, org, date):
+    prompt = OrganizationMetricUpdatePrompt(responsible_user=user,
+                                            org=org,
+                                            latest_metric_submission=date,
+                                            year=False,
+                                            year_month=False,
+                                            year_three_month=False,
+                                            year_six_month=False
+                                            )
+    prompt.save()
+    return prompt
+
+
+def get_expected_org_metric_update_prompts(current_date):
+    return [
+        {
+            "latest_metric_submission": current_date,
+            "year": False,
+            "year_month": False,
+            "year_three_month": False,
+            "year_six_month": False,
+        },
+        {
+            "latest_metric_submission": current_date - timedelta(days=366),
+            "year": True,
+            "year_month": False,
+            "year_three_month": False,
+            "year_six_month": False,
+        },
+        {
+            "latest_metric_submission": current_date - timedelta(days=466),
+            "year": True,
+            "year_month": True,
+            "year_three_month": True,
+            "year_six_month": False,
+        }
+    ]

--- a/common/djangoapps/philu_commands/management/commands/tests/update_org_oef_test_api.py
+++ b/common/djangoapps/philu_commands/management/commands/tests/update_org_oef_test_api.py
@@ -1,0 +1,59 @@
+# encoding: utf-8
+"""Tests of Management Commands """
+from __future__ import unicode_literals
+
+from datetime import timedelta
+
+from django.core.management import call_command
+from django.test import TestCase
+from django.contrib.auth.models import User
+
+from lms.djangoapps.oef.models import OrganizationOefUpdatePrompt
+from lms.djangoapps.onboarding.helpers import get_current_utc_date
+from lms.djangoapps.onboarding.models import Organization
+
+
+class OrganizationOef(TestCase):
+    """Test Command to update Organization OEF Prompts"""
+
+    def test_update_org_today_oef(self):
+        user = User(username='usman', email='usman@gmail.com', first_name='usman',
+                    last_name='khan', password='abc123', is_active=True)
+        user.save()
+        org = Organization(label='Home')
+        org.save()
+        today = get_current_utc_date()
+        save_oef_prompt(user, org, today)
+
+        call_command('update_org_oef_prompts')
+        today_oef_prompts = OrganizationOefUpdatePrompt.objects.filter(latest_finish_date=today).values(
+            "latest_finish_date", "year").first()
+
+        """ Should be False for today """
+        self.assertEqual(today_oef_prompts['year'], False)
+
+    def test_update_org_one_year_old_oef(self):
+        user = User(username='muak', email='muak@gmail.com', first_name='usman',
+                    last_name='arshad', password='abc123', is_active=True)
+        user.save()
+        org = Organization(label='Home')
+        org.save()
+        today = get_current_utc_date()
+        one_year_old_date = today - timedelta(days=366)
+        save_oef_prompt(user, org, one_year_old_date)
+
+        call_command('update_org_oef_prompts')
+        one_year_old_oef_prompts = OrganizationOefUpdatePrompt.objects.filter(
+            latest_finish_date=one_year_old_date).values("latest_finish_date", "year").first()
+
+        """ Should be True for one year old date """
+        self.assertEqual(one_year_old_oef_prompts['year'], True)
+
+
+def save_oef_prompt(user, org, date):
+    prompt = OrganizationOefUpdatePrompt(responsible_user=user,
+                                         org=org,
+                                         latest_finish_date=date,
+                                         year=False,
+                                         )
+    prompt.save()


### PR DESCRIPTION
```
Coverage for common/djangoapps/philu_commands/management/commands/create_certificates_image.py : 100%

Coverage for common/djangoapps/philu_commands/management/commands/delete_users_from_mailchimp.py : 100%

Coverage for common/djangoapps/philu_commands/management/commands/sync_users_with_mailchimp.py : 100%

Coverage for common/djangoapps/philu_commands/management/commands/sync_users_with_nodebb.py : 97%
```