### PR TITLE
User api tests

### DIFF
--- a/lms/djangoapps/philu_overrides/user_api/tests/test_views.py
+++ b/lms/djangoapps/philu_overrides/user_api/tests/test_views.py
@@ -1,0 +1,2165 @@
+"""Tests for the user API at the HTTP request level. """
+
+import datetime
+import ddt
+import factory
+import json
+import mock
+from unittest import skipUnless, SkipTest
+
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.core import mail
+from django.core.urlresolvers import reverse
+from django.db.models.signals import post_save
+from django.test.client import RequestFactory
+from django.test.utils import override_settings
+from pytz import UTC
+
+from common.djangoapps.student.views import AccountValidationError
+from django_comment_common import models
+from openedx.core.lib.api.test_utils import ApiTestCase
+from lms.djangoapps.onboarding.tests.factories import UserFactory
+from third_party_auth.tests.testutil import simulate_running_pipeline, ThirdPartyAuthTestMixin
+from openedx.core.djangoapps.user_api.tests.test_helpers import TestCaseForm
+from openedx.core.djangoapps.user_api.tests.test_constants import SORTED_COUNTRIES
+from openedx.core.djangoapps.user_api.accounts.api import get_account_settings
+from openedx.core.djangoapps.user_api.accounts import (
+    NAME_MAX_LENGTH, EMAIL_MIN_LENGTH, EMAIL_MAX_LENGTH, PASSWORD_MIN_LENGTH, PASSWORD_MAX_LENGTH,
+    USERNAME_MIN_LENGTH, USERNAME_MAX_LENGTH
+)
+
+@ddt.ddt
+@skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+class LoginSessionViewTest(ApiTestCase):
+    """Tests for the login end-points of the user API. """
+
+    USERNAME = "bob"
+    EMAIL = "bob@example.com"
+    PASSWORD = "password"
+
+    def setUp(self):
+        super(LoginSessionViewTest, self).setUp()
+        self.url = reverse("user_api_login_session")
+
+    @ddt.data("get", "post")
+    def test_auth_disabled(self, method):
+        self.assertAuthDisabled(method, self.url)
+
+    def test_allowed_methods(self):
+        self.assertAllowedMethods(self.url, ["GET", "POST", "HEAD", "OPTIONS"])
+
+    def test_put_not_allowed(self):
+        response = self.client.put(self.url)
+        self.assertHttpMethodNotAllowed(response)
+
+    def test_delete_not_allowed(self):
+        response = self.client.delete(self.url)
+        self.assertHttpMethodNotAllowed(response)
+
+    def test_patch_not_allowed(self):
+        response = self.client.patch(self.url)
+        self.assertHttpMethodNotAllowed(response)
+
+    def test_login_form(self):
+        # Retrieve the login form
+        response = self.client.get(self.url, content_type="application/json")
+        self.assertHttpOK(response)
+
+        # Verify that the form description matches what we expect
+        form_desc = json.loads(response.content)
+        self.assertEqual(form_desc["method"], "post")
+        self.assertEqual(form_desc["submit_url"], self.url)
+        self.assertItemsEqual(form_desc["fields"], [
+            {
+                "name": "email",
+                "defaultValue": "",
+                "type": "email",
+                "required": True,
+                "label": "Email",
+                "placeholder": "username@domain.com",
+                "instructions": u"The email address you used to register with {platform_name}".format(
+                    platform_name=settings.PLATFORM_NAME
+                ),
+                "restrictions": {
+                    "min_length": EMAIL_MIN_LENGTH,
+                    "max_length": EMAIL_MAX_LENGTH
+                },
+                "errorMessages": {},
+                "supplementalText": "",
+                "supplementalLink": "",
+            },
+            {
+                "name": "password",
+                "defaultValue": "",
+                "type": "password",
+                "required": True,
+                "label": "Password",
+                "placeholder": "",
+                "instructions": "",
+                "restrictions": {
+                    "min_length": PASSWORD_MIN_LENGTH,
+                    "max_length": PASSWORD_MAX_LENGTH
+                },
+                "errorMessages": {},
+                "supplementalText": "",
+                "supplementalLink": "",
+            },
+            {
+                "name": "remember",
+                "defaultValue": False,
+                "type": "checkbox",
+                "required": False,
+                "label": "Remember my login credentials so I don't need to fill up these fields every time I log in.",
+                "placeholder": "",
+                "instructions": "",
+                "restrictions": {},
+                "errorMessages": {},
+                "supplementalText": "",
+                "supplementalLink": "",
+            },
+        ])
+
+    @factory.django.mute_signals(post_save)
+    def test_login(self):
+        # Create a test user
+        user = UserFactory.create(username=self.USERNAME, email=self.EMAIL, password=self.PASSWORD)
+
+        # Login
+        response = self.client.post(self.url, {
+            "email": self.EMAIL,
+            "password": self.PASSWORD,
+        })
+        self.assertHttpOK(response)
+
+        user.profile.level_of_education = 'BD'
+        user.extended_profile.english_proficiency = 'ADV'
+        user.profile.save()
+        user.extended_profile.save()
+
+        # Verify that we logged in successfully by accessing
+        # a page that requires authentication.
+        response = self.client.get(reverse("learner_profile", kwargs={'username': user.username}))
+        self.assertHttpOK(response)
+
+    @ddt.data(
+        ('true', False),
+        ('false', True),
+        (None, True),
+    )
+    @ddt.unpack
+    @factory.django.mute_signals(post_save)
+    def test_login_remember_me(self, remember_value, expire_at_browser_close):
+        # Create a test user
+        UserFactory.create(username=self.USERNAME, email=self.EMAIL, password=self.PASSWORD)
+
+        # Login and remember me
+        data = {
+            "email": self.EMAIL,
+            "password": self.PASSWORD,
+        }
+
+        if remember_value is not None:
+            data["remember"] = remember_value
+
+        response = self.client.post(self.url, data)
+        self.assertHttpOK(response)
+
+        # Verify that the session expiration was set correctly
+        self.assertEqual(
+            self.client.session.get_expire_at_browser_close(),
+            expire_at_browser_close
+        )
+
+    @factory.django.mute_signals(post_save)
+    def test_invalid_credentials(self):
+        # Create a test user
+        UserFactory.create(username=self.USERNAME, email=self.EMAIL, password=self.PASSWORD)
+
+        # Invalid password
+        response = self.client.post(self.url, {
+            "email": self.EMAIL,
+            "password": "invalid"
+        })
+        self.assertHttpForbidden(response)
+
+        # Invalid email address
+        response = self.client.post(self.url, {
+            "email": "invalid@example.com",
+            "password": self.PASSWORD,
+        })
+        self.assertHttpForbidden(response)
+    
+    @factory.django.mute_signals(post_save)
+    def test_missing_login_params(self):
+        # Create a test user
+        UserFactory.create(username=self.USERNAME, email=self.EMAIL, password=self.PASSWORD)
+
+        # Missing password
+        response = self.client.post(self.url, {
+            "email": self.EMAIL,
+        })
+        self.assertHttpBadRequest(response)
+
+        # Missing email
+        response = self.client.post(self.url, {
+            "password": self.PASSWORD,
+        })
+        self.assertHttpBadRequest(response)
+
+        # Missing both email and password
+        response = self.client.post(self.url, {})
+        self.assertHttpBadRequest(response)
+
+
+@override_settings(
+    MIDDLEWARE_CLASSES=[
+        klass for klass in settings.MIDDLEWARE_CLASSES
+        if klass != 'lms.djangoapps.onboarding.middleware.RedirectMiddleware'
+    ]
+)
+@ddt.ddt
+@skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+class RegistrationViewTest(ThirdPartyAuthTestMixin, ApiTestCase):
+    """Tests for the registration version one end-points of the User API. """
+
+    maxDiff = None
+
+    USERNAME = "bob"
+    EMAIL = "bob@example.com"
+    PASSWORD = "password"
+    NAME = "Bob Smith"
+    FIRSTNAME = "Bob"
+    LASTNAME = "Smith"
+    EDUCATION = "m"
+    YEAR_OF_BIRTH = "1998"
+    ADDRESS = "123 Fake Street"
+    CITY = "Springfield"
+    COUNTRY = "us"
+    GOALS = "Learn all the things!"
+
+    def setUp(self):
+        super(RegistrationViewTest, self).setUp()
+        self.url = reverse("user_api_registration")
+
+    @ddt.data("get", "post")
+    def test_auth_disabled(self, method):
+        self.assertAuthDisabled(method, self.url)
+
+    def test_allowed_methods(self):
+        self.assertAllowedMethods(self.url, ["GET", "POST", "HEAD", "OPTIONS"])
+
+    def test_put_not_allowed(self):
+        response = self.client.put(self.url)
+        self.assertHttpMethodNotAllowed(response)
+
+    def test_delete_not_allowed(self):
+        response = self.client.delete(self.url)
+        self.assertHttpMethodNotAllowed(response)
+
+    def test_patch_not_allowed(self):
+        raise SkipTest("Django 1.4's test client does not support patch")
+
+    def test_register_form_default_fields(self):
+        no_extra_fields_setting = {}
+
+        self._assert_reg_field(
+            no_extra_fields_setting,
+            {
+                u"name": u"email",
+                u"type": u"email",
+                u"required": True,
+                u"label": u"Email",
+                u"placeholder": u"username@domain.com",
+                u"restrictions": {
+                    "min_length": EMAIL_MIN_LENGTH,
+                    "max_length": EMAIL_MAX_LENGTH
+                },
+                u"errorMessages": {
+                    u"email": u"The email you entered is not valid. Please provide"
+                    u" a valid email in order to create an account."
+                }
+            }
+        )
+
+
+        self._assert_reg_field(
+            no_extra_fields_setting,
+            {
+                u"name": u"username",
+                u"type": u"text",
+                u"required": True,
+                u"label": u"Public Username",
+                u"placeholder": u"Public Username",
+                u"instructions": u"The name that will identify you in your courses - <strong>(cannot be changed later)</strong>",  # pylint: disable=line-too-long
+                u"restrictions": {
+                    "min_length": USERNAME_MIN_LENGTH,
+                    "max_length": USERNAME_MAX_LENGTH
+                },
+            }
+        )
+
+        self._assert_reg_field(
+            no_extra_fields_setting,
+            {
+                u"placeholder": "Password",
+                u"name": u"password",
+                u"type": u"password",
+                u"required": True,
+                u"label": u"Password",
+                u"restrictions": {
+                    'min_length': PASSWORD_MIN_LENGTH,
+                    'max_length': PASSWORD_MAX_LENGTH
+                },
+            }
+        )
+
+    @override_settings(REGISTRATION_EXTENSION_FORM='openedx.core.djangoapps.user_api.tests.test_helpers.TestCaseForm')
+    def test_extension_form_fields(self):
+        no_extra_fields_setting = {}
+
+        # Verify other fields didn't disappear for some reason.
+        self._assert_reg_field(
+            no_extra_fields_setting,
+            {
+                u"name": u"email",
+                u"type": u"email",
+                u"required": True,
+                u"label": u"Email",
+                u"placeholder": u"username@domain.com",
+                u"restrictions": {
+                    "min_length": EMAIL_MIN_LENGTH,
+                    "max_length": EMAIL_MAX_LENGTH
+                },
+                u"errorMessages": {
+                    u"email": u"The email you entered is not valid. Please provide"
+                    u" a valid email in order to create an account."
+                }
+            }
+        )
+
+        self._assert_reg_field(
+            no_extra_fields_setting,
+            {
+                u"name": u"favorite_editor",
+                u"type": u"select",
+                u"required": False,
+                u"label": u"Favorite Editor",
+                u"placeholder": u"cat",
+                u"defaultValue": u"vim",
+                u"errorMessages": {
+                    u'required': u'This field is required.',
+                    u'invalid_choice': u'Select a valid choice. %(value)s is not one of the available choices.',
+                }
+            }
+        )
+
+        self._assert_reg_field(
+            no_extra_fields_setting,
+            {
+                u"name": u"favorite_movie",
+                u"type": u"text",
+                u"required": True,
+                u"label": u"Fav Flick",
+                u"placeholder": None,
+                u"defaultValue": None,
+                u"errorMessages": {
+                    u'required': u'Please tell us your favorite movie.',
+                    u'invalid': u"We're pretty sure you made that movie up."
+                },
+                u"restrictions": {
+                    "min_length": TestCaseForm.MOVIE_MIN_LEN,
+                    "max_length": TestCaseForm.MOVIE_MAX_LEN,
+                }
+            }
+        )
+
+    def test_register_form_third_party_auth_running(self):
+        no_extra_fields_setting = {}
+
+        self.configure_google_provider(enabled=True)
+        with simulate_running_pipeline(
+            "openedx.core.djangoapps.user_api.views.third_party_auth.pipeline",
+            "google-oauth2", email="bob@example.com",
+            fullname="Bob", username="Bob123"
+        ):
+            # Password field should be hidden
+            self._assert_reg_field(
+                no_extra_fields_setting,
+                {
+                    u"placeholder": "Password",
+                    u"name": u"password",
+                    u"type": u"password",
+                    u"label": u"Password",
+                    u"required": True,
+                    u"restrictions": {
+                        'min_length': PASSWORD_MIN_LENGTH,
+                        'max_length': PASSWORD_MAX_LENGTH
+                    },
+                }
+            )
+
+            # Email should be filled in
+            self._assert_reg_field(
+                no_extra_fields_setting,
+                {
+                    u"name": u"email",
+                    u"defaultValue": u"bob@example.com",
+                    u"type": u"email",
+                    u"required": True,
+                    u"label": u"Email",
+                    u"placeholder": u"username@domain.com",
+                    u"restrictions": {
+                        "min_length": EMAIL_MIN_LENGTH,
+                        "max_length": EMAIL_MAX_LENGTH
+                    },
+                    u"errorMessages": {
+                        u"email": u"The email you entered is not valid. Please provide"
+                        u" a valid email in order to create an account."
+                    }
+                }
+            )
+
+            self._assert_reg_field(
+                no_extra_fields_setting,
+                {
+                    u"name": u"first_name",
+                    u"defaultValue": u"",
+                    u"type": u"text",
+                    u"required": True,
+                    u"instructions": u"",
+                    u"label": u"First Name",
+                    u"placeholder": None,
+                    u"restrictions": {},
+                    u"errorMessages": {u"required": u"Please enter your First Name."}
+                }
+            )
+
+            self._assert_reg_field(
+                no_extra_fields_setting,
+                {
+                    u"name": u"last_name",
+                    u"defaultValue": u"",
+                    u"type": u"text",
+                    u"required": True,
+                    u"instructions": u"",
+                    u"label": u"Last Name",
+                    u"placeholder": None,
+                    u"restrictions": {},
+                    u"errorMessages": {u"required": u"Please enter your Last Name."}
+                }
+            )
+
+            # Username should be filled in
+            self._assert_reg_field(
+                no_extra_fields_setting,
+                {
+                    u"name": u"username",
+                    u"defaultValue": u"Bob123",
+                    u"type": u"text",
+                    u"required": True,
+                    u"label": u"Public Username",
+                    u"placeholder": u"Public Username",
+                    u"instructions": u"The name that will identify you in your courses - <strong>(cannot be changed later)</strong>",  # pylint: disable=line-too-long
+                    u"restrictions": {
+                        "min_length": USERNAME_MIN_LENGTH,
+                        "max_length": USERNAME_MAX_LENGTH
+                    }
+                }
+            )
+
+    def test_register_form_level_of_education(self):
+        self._assert_reg_field(
+            {"level_of_education": "optional"},
+            {
+                "name": "level_of_education",
+                "type": "select",
+                "required": False,
+                "label": "Highest level of education completed",
+                "options": [
+                    {"value": "", "name": "--", "default": True},
+                    {"value": "p", "name": "Doctorate"},
+                    {"value": "m", "name": "Master's or professional degree"},
+                    {"value": "b", "name": "Bachelor's degree"},
+                    {"value": "a", "name": "Associate degree"},
+                    {"value": "hs", "name": "Secondary/high school"},
+                    {"value": "jhs", "name": "Junior secondary/junior high/middle school"},
+                    {"value": "el", "name": "Elementary/primary school"},
+                    {"value": "none", "name": "No formal education"},
+                    {"value": "other", "name": "Other education"},
+                ],
+            }
+        )
+
+    @mock.patch('util.enterprise_helpers.active_provider_requests_data_sharing')
+    @mock.patch('util.enterprise_helpers.active_provider_enforces_data_sharing')
+    @mock.patch('util.enterprise_helpers.get_enterprise_customer_for_request')
+    @mock.patch('util.enterprise_helpers.configuration_helpers')
+    def test_register_form_consent_field(self, config_helper, get_ec, mock_enforce, mock_request):
+        """
+        Test that if we have an EnterpriseCustomer active for the request, and that
+        EnterpriseCustomer is set to require data sharing consent, the correct
+        field is added to the form descriptor.
+        """
+        fake_ec = mock.MagicMock(
+            enforces_data_sharing_consent=mock.MagicMock(return_value=True),
+            requests_data_sharing_consent=True,
+        )
+        fake_ec.name = 'MegaCorp'
+        get_ec.return_value = fake_ec
+        config_helper.get_value.return_value = 'OpenEdX'
+        mock_request.return_value = True
+        mock_enforce.return_value = True
+        self._assert_reg_field(
+            dict(),
+            {
+                u"name": u"data_sharing_consent",
+                u"type": u"checkbox",
+                u"required": True,
+                u"label": (
+                    "I agree to allow OpenEdX to share data about my enrollment, "
+                    "completion and performance in all OpenEdX courses and programs "
+                    "where my enrollment is sponsored by MegaCorp."
+                ),
+                u"defaultValue": False,
+                u"errorMessages": {
+                    u'required': u'To link your account with MegaCorp, you are required to consent to data sharing.',
+                }
+            }
+        )
+
+    @mock.patch('openedx.core.djangoapps.user_api.views._')
+    def test_register_form_level_of_education_translations(self, fake_gettext):
+        fake_gettext.side_effect = lambda text: text + ' TRANSLATED'
+
+        self._assert_reg_field(
+            {"level_of_education": "optional"},
+            {
+                "name": "level_of_education",
+                "type": "select",
+                "required": False,
+                "label": "Highest level of education completed TRANSLATED",
+                "options": [
+                    {"value": "", "name": "--", "default": True},
+                    {"value": "p", "name": "Doctorate TRANSLATED"},
+                    {"value": "m", "name": "Master's or professional degree TRANSLATED"},
+                    {"value": "b", "name": "Bachelor's degree TRANSLATED"},
+                    {"value": "a", "name": "Associate degree TRANSLATED"},
+                    {"value": "hs", "name": "Secondary/high school TRANSLATED"},
+                    {"value": "jhs", "name": "Junior secondary/junior high/middle school TRANSLATED"},
+                    {"value": "el", "name": "Elementary/primary school TRANSLATED"},
+                    {"value": "none", "name": "No formal education TRANSLATED"},
+                    {"value": "other", "name": "Other education TRANSLATED"},
+                ],
+            }
+        )
+
+    def test_register_form_gender(self):
+        self._assert_reg_field(
+            {"gender": "optional"},
+            {
+                "name": "gender",
+                "type": "select",
+                "required": False,
+                "label": "Gender",
+                "options": [
+                    {"value": "", "name": "--", "default": True},
+                    {"value": "m", "name": "Male"},
+                    {"value": "f", "name": "Female"},
+                    {"value": "o", "name": "Other/Prefer Not to Say"},
+                ],
+            }
+        )
+
+    @mock.patch('openedx.core.djangoapps.user_api.views._')
+    def test_register_form_gender_translations(self, fake_gettext):
+        fake_gettext.side_effect = lambda text: text + ' TRANSLATED'
+
+        self._assert_reg_field(
+            {"gender": "optional"},
+            {
+                "name": "gender",
+                "type": "select",
+                "required": False,
+                "label": "Gender TRANSLATED",
+                "options": [
+                    {"value": "", "name": "--", "default": True},
+                    {"value": "m", "name": "Male TRANSLATED"},
+                    {"value": "f", "name": "Female TRANSLATED"},
+                    {"value": "o", "name": "Other/Prefer Not to Say TRANSLATED"},
+                ],
+            }
+        )
+
+    def test_register_form_year_of_birth(self):
+        this_year = datetime.datetime.now(UTC).year
+        year_options = (
+            [{"value": "", "name": "--", "default": True}] + [
+                {"value": unicode(year), "name": unicode(year)}
+                for year in range(this_year, this_year - 120, -1)
+            ]
+        )
+        self._assert_reg_field(
+            {"year_of_birth": "optional"},
+            {
+                "name": "year_of_birth",
+                "type": "select",
+                "required": False,
+                "label": "Year of birth",
+                "options": year_options,
+            }
+        )
+
+    def test_registration_form_mailing_address(self):
+        self._assert_reg_field(
+            {"mailing_address": "optional"},
+            {
+                "name": "mailing_address",
+                "type": "textarea",
+                "required": False,
+                "label": "Mailing address",
+            }
+        )
+
+    def test_registration_form_goals(self):
+        self._assert_reg_field(
+            {"goals": "optional"},
+            {
+                "name": "goals",
+                "type": "textarea",
+                "required": False,
+                "label": u"Tell us why you're interested in {platform_name}".format(
+                    platform_name=settings.PLATFORM_NAME
+                )
+            }
+        )
+
+    def test_registration_form_city(self):
+        self._assert_reg_field(
+            {"city": "optional"},
+            {
+                "name": "city",
+                "type": "text",
+                "required": False,
+                "label": "City",
+            }
+        )
+
+    def test_registration_form_state(self):
+        self._assert_reg_field(
+            {"state": "optional"},
+            {
+                "name": "state",
+                "type": "text",
+                "required": False,
+                "label": "State/Province/Region",
+            }
+        )
+
+    def test_registration_form_country(self):
+        country_options = (
+            [{"name": "--", "value": "", "default": True}] +
+            [
+                {"value": country_code, "name": unicode(country_name)}
+                for country_code, country_name in SORTED_COUNTRIES
+            ]
+        )
+        self._assert_reg_field(
+            {"country": "required"},
+            {
+                "label": "Country",
+                "name": "country",
+                "type": "select",
+                "required": True,
+                "options": country_options,
+                "errorMessages": {
+                    "required": "Please select your Country."
+                },
+            }
+        )
+
+    @override_settings(
+        MKTG_URLS={"ROOT": "https://www.test.com/", "HONOR": "honor"},
+    )
+    @mock.patch.dict(settings.FEATURES, {"ENABLE_MKTG_SITE": True})
+    def test_registration_honor_code_mktg_site_enabled(self):
+        link_label = 'Terms of Service and Honor Code'
+        self._assert_reg_field(
+            {"honor_code": "required"},
+            {
+                "label": u"Check here if you agree to be bound by, and to comply with, our ",
+                "name": "honor_code",
+                "defaultValue": False,
+                "type": "checkbox",
+                "required": True,
+                "errorMessages": {
+                    "required": "Please accept our Terms and Conditions by checking the Terms and Conditions" \
+                    " checkbox before creating an account."
+                }
+            }
+        )
+
+    @override_settings(MKTG_URLS_LINK_MAP={"HONOR": "honor"})
+    @mock.patch.dict(settings.FEATURES, {"ENABLE_MKTG_SITE": False})
+    def test_registration_honor_code_mktg_site_disabled(self):
+        link_label = 'Terms of Service and Honor Code'
+        self._assert_reg_field(
+            {"honor_code": "required"},
+            {
+                "label": u"Check here if you agree to be bound by, and to comply with, our ",
+                "name": "honor_code",
+                "defaultValue": False,
+                "type": "checkbox",
+                "required": True,
+                "errorMessages": {
+                    "required": "Please accept our Terms and Conditions by checking the Terms and Conditions" \
+                    " checkbox before creating an account."
+                }
+            }
+        )
+
+    @override_settings(MKTG_URLS={
+        "ROOT": "https://www.test.com/",
+        "HONOR": "honor",
+        "TOS": "tos",
+    })
+    @mock.patch.dict(settings.FEATURES, {"ENABLE_MKTG_SITE": True})
+    def test_registration_separate_terms_of_service_mktg_site_enabled(self):
+        # Honor code field should say ONLY honor code,
+        # not "terms of service and honor code"
+        link_label = 'Honor Code'
+        self._assert_reg_field(
+            {"honor_code": "required", "terms_of_service": "required"},
+            {
+                "label": u"Check here if you agree to be bound by, and to comply with, our ",
+                "name": "honor_code",
+                "defaultValue": False,
+                "type": "checkbox",
+                "required": True,
+                "errorMessages": {
+                    "required": "Please accept our Terms and Conditions by checking the Terms and Conditions" \
+                    " checkbox before creating an account."
+                }                
+            }
+        )
+
+        # Terms of service field should also be present
+        link_label = 'Terms of Service'
+        self._assert_reg_field(
+            {"honor_code": "required", "terms_of_service": "required"},
+            {
+                "label": u"I agree to the {platform_name} {link_label}".format(
+                    platform_name=settings.PLATFORM_NAME,
+                    link_label=link_label
+                ),
+                "name": "terms_of_service",
+                "defaultValue": False,
+                "type": "checkbox",
+                "required": True,
+                "errorMessages": {
+                    "required": u"You must agree to the {platform_name} {link_label}".format(
+                        platform_name=settings.PLATFORM_NAME,
+                        link_label=link_label
+                    )
+                }
+            }
+        )
+
+    @override_settings(MKTG_URLS_LINK_MAP={"HONOR": "honor", "TOS": "tos"})
+    @mock.patch.dict(settings.FEATURES, {"ENABLE_MKTG_SITE": False})
+    def test_registration_separate_terms_of_service_mktg_site_disabled(self):
+        # Honor code field should say ONLY honor code,
+        # not "terms of service and honor code"
+        self._assert_reg_field(
+            {"honor_code": "required", "terms_of_service": "required"},
+            {
+                "label": u"Check here if you agree to be bound by, and to comply with, our ",
+                "name": "honor_code",
+                "defaultValue": False,
+                "type": "checkbox",
+                "required": True,
+                "errorMessages": {
+                    "required": "Please accept our Terms and Conditions by checking the Terms and Conditions" \
+                    " checkbox before creating an account."
+                }                
+            }
+        )
+
+        # Terms of service field should also be present
+        self._assert_reg_field(
+            {"honor_code": "required", "terms_of_service": "required"},
+            {
+                "label": u"I agree to the {platform_name} Terms of Service".format(
+                    platform_name=settings.PLATFORM_NAME
+                ),
+                "name": "terms_of_service",
+                "defaultValue": False,
+                "type": "checkbox",
+                "required": True,
+                "errorMessages": {
+                    "required": u"You must agree to the {platform_name} Terms of Service".format(  # pylint: disable=line-too-long
+                        platform_name=settings.PLATFORM_NAME
+                    )
+                }
+            }
+        )
+
+    @override_settings(
+        REGISTRATION_EXTRA_FIELDS={
+            "level_of_education": "optional",
+            "gender": "optional",
+            "year_of_birth": "optional",
+            "mailing_address": "optional",
+            "goals": "optional",
+            "city": "optional",
+            "state": "optional",
+            "country": "required",
+            "honor_code": "required",
+        },
+        REGISTRATION_EXTENSION_FORM='openedx.core.djangoapps.user_api.tests.test_helpers.TestCaseForm',
+    )
+    def test_field_order(self):
+        response = self.client.get(self.url)
+        self.assertHttpOK(response)
+
+        # Verify that all fields render in the correct order
+        form_desc = json.loads(response.content)
+        field_names = [field["name"] for field in form_desc["fields"]]
+        self.assertEqual(field_names, [
+            u"email",
+            u"username",
+            u"password",
+            u"favorite_movie",
+            u"favorite_editor",
+            u"city",
+            u"state",
+            u"country",
+            u"gender",
+            u"year_of_birth",
+            u"level_of_education",
+            u"mailing_address",
+            u"goals",
+            u"honor_code"
+        ])
+
+    @factory.django.mute_signals(post_save)
+    def test_register(self):
+        # Create a new registration
+        response = self.client.post(self.url, {
+            "email": self.EMAIL,
+            "name": self.NAME,
+            "username": self.USERNAME,
+            "password": self.PASSWORD,
+            "honor_code": "true",
+            "first_name": self.FIRSTNAME,
+            "last_name": self.LASTNAME,
+            "confirm_password": self.PASSWORD,
+            "is_poc": 1,
+            "partners_opt_in": ""
+        })
+        self.assertHttpOK(response)
+        self.assertIn(settings.EDXMKTG_LOGGED_IN_COOKIE_NAME, self.client.cookies)
+        self.assertIn(settings.EDXMKTG_USER_INFO_COOKIE_NAME, self.client.cookies)
+
+        user = User.objects.get(username=self.USERNAME)
+        request = RequestFactory().get('/url')
+        request.user = user
+        account_settings = get_account_settings(request)[0]
+
+        self.assertEqual(self.USERNAME, account_settings["username"])
+        self.assertEqual(self.EMAIL, account_settings["email"])
+        self.assertFalse(account_settings["is_active"])
+        self.assertEqual(self.NAME, account_settings["name"])
+
+        # Verify that we've been logged in
+        # by trying to access a page that requires authentication
+        response = self.client.get(reverse("learner_profile", kwargs={'username': self.USERNAME}))
+        self.assertHttpOK(response)
+
+    @override_settings(REGISTRATION_EXTRA_FIELDS={
+        "level_of_education": "optional",
+        "gender": "optional",
+        "year_of_birth": "optional",
+        "mailing_address": "optional",
+        "goals": "optional",
+        "country": "required",
+    })
+    @factory.django.mute_signals(post_save)
+    def test_register_with_profile_info(self):
+        # Register, providing lots of demographic info
+        response = self.client.post(self.url, {
+            "email": self.EMAIL,
+            "name": self.NAME,
+            "username": self.USERNAME,
+            "password": self.PASSWORD,
+            "level_of_education": self.EDUCATION,
+            "mailing_address": self.ADDRESS,
+            "year_of_birth": self.YEAR_OF_BIRTH,
+            "goals": self.GOALS,
+            "country": self.COUNTRY,
+            "honor_code": "true",
+            "first_name": self.FIRSTNAME,
+            "last_name": self.LASTNAME,
+            "confirm_password": self.PASSWORD,
+            "is_poc": 1,
+            "partners_opt_in": ""
+        })
+        self.assertHttpOK(response)
+
+        # Verify the user's account
+        user = User.objects.get(username=self.USERNAME)
+        request = RequestFactory().get('/url')
+        request.user = user
+        account_settings = get_account_settings(request)[0]
+
+        self.assertEqual(account_settings["level_of_education"], self.EDUCATION)
+        self.assertEqual(account_settings["mailing_address"], self.ADDRESS)
+        self.assertEqual(account_settings["year_of_birth"], int(self.YEAR_OF_BIRTH))
+        self.assertEqual(account_settings["goals"], self.GOALS)
+        self.assertEqual(account_settings["country"], self.COUNTRY)
+
+    # @override_settings(REGISTRATION_EXTENSION_FORM='openedx.core.djangoapps.user_api.tests.test_helpers.TestCaseForm')
+    # @mock.patch('openedx.core.djangoapps.user_api.tests.test_helpers.TestCaseForm.DUMMY_STORAGE', new_callable=dict)
+    # @mock.patch(
+    #     'openedx.core.djangoapps.user_api.tests.test_helpers.DummyRegistrationExtensionModel',
+    # )
+    # @factory.django.mute_signals(post_save)    
+    # def test_with_extended_form(self, dummy_model, storage_dict):
+    #     import pdb; pdb.set_trace()
+    #     dummy_model_instance = mock.Mock()
+    #     dummy_model.return_value = dummy_model_instance
+    #     # Create a new registration
+    #     self.assertEqual(storage_dict, {})
+    #     response = self.client.post(self.url, {
+    #         "email": self.EMAIL,
+    #         "name": self.NAME,
+    #         "username": self.USERNAME,
+    #         "password": self.PASSWORD,
+    #         "honor_code": "true",
+    #         "favorite_movie": "Inception",
+    #         "favorite_editor": "cat",
+    #         "first_name": self.FIRSTNAME,
+    #         "last_name": self.LASTNAME,
+    #         "confirm_password": self.PASSWORD,
+    #         "is_poc": 1,
+    #         "partners_opt_in": ""
+    #     })
+    #     self.assertHttpOK(response)
+    #     self.assertIn(settings.EDXMKTG_LOGGED_IN_COOKIE_NAME, self.client.cookies)
+    #     self.assertIn(settings.EDXMKTG_USER_INFO_COOKIE_NAME, self.client.cookies)
+
+    #     user = User.objects.get(username=self.USERNAME)
+    #     request = RequestFactory().get('/url')
+    #     request.user = user
+    #     account_settings = get_account_settings(request)[0]
+
+    #     self.assertEqual(self.USERNAME, account_settings["username"])
+    #     self.assertEqual(self.EMAIL, account_settings["email"])
+    #     self.assertFalse(account_settings["is_active"])
+    #     self.assertEqual(self.NAME, account_settings["name"])
+
+    #     self.assertEqual(storage_dict, {'favorite_movie': "Inception", "favorite_editor": "cat"})
+    #     self.assertEqual(dummy_model_instance.user, user)
+
+    #     # Verify that we've been logged in
+    #     # by trying to access a page that requires authentication
+    #     response = self.client.get(reverse("learner_profile", kwargs={'username': self.USERNAME}))
+    #     self.assertHttpOK(response)
+
+    @mock.patch('mailchimp_pipeline.signals.handlers.task_send_account_activation_email')
+    @factory.django.mute_signals(post_save)    
+    def test_activation_email(self, mock_func):
+        # Register, which should trigger an activation email
+        response = self.client.post(self.url, {
+            "email": self.EMAIL,
+            "name": self.NAME,
+            "username": self.USERNAME,
+            "password": self.PASSWORD,
+            "honor_code": "true",
+            "first_name": self.FIRSTNAME,
+            "last_name": self.LASTNAME,
+            "confirm_password": self.PASSWORD,
+            "is_poc": 1,
+            "partners_opt_in": ""
+        })
+        self.assertHttpOK(response)
+
+        # Verify that the activation email was sent
+        mock_func.assert_called_once()
+
+    @ddt.data(
+        {"email": ""},
+        {"email": "invalid"},
+        {"first_name": ""},
+        {"last_name": ""},
+        {"username": ""},
+        {"username": "a"},
+        {"password": ""},
+    )
+    def test_register_invalid_input(self, invalid_fields):
+        # Initially, the field values are all valid
+        data = {
+            "email": self.EMAIL,
+            "name": self.NAME,
+            "username": self.USERNAME,
+            "password": self.PASSWORD,
+            "honor_code": "true",
+            "first_name": self.FIRSTNAME,
+            "last_name": self.LASTNAME,
+            "confirm_password": self.PASSWORD,
+            "is_poc": 1,
+            "partners_opt_in": ""
+        }
+        # Override the valid fields, making the input invalid
+        data.update(invalid_fields)
+
+        # Attempt to create the account, expecting an error response
+        response = self.client.post(self.url, data)
+        self.assertHttpBadRequest(response)
+
+    @override_settings(REGISTRATION_EXTRA_FIELDS={"country": "required"})
+    @ddt.data("email", "username", "password", "country", ("first_name", "last_name"))
+    def test_register_missing_required_field(self, missing_field):
+        data = {
+            "email": self.EMAIL,
+            "name": self.NAME,
+            "username": self.USERNAME,
+            "password": self.PASSWORD,
+            "country": self.COUNTRY,
+            "honor_code": "true",
+            "first_name": self.FIRSTNAME,
+            "last_name": self.LASTNAME,
+            "confirm_password": self.PASSWORD,
+            "is_poc": 1,
+            "partners_opt_in": ""
+        }
+
+        if isinstance(missing_field, tuple):
+            for key in missing_field:
+                del data[key]
+        else:
+            del data[missing_field]
+
+        # Send a request missing a field
+        response = self.client.post(self.url, data)
+        self.assertHttpBadRequest(response)
+
+    def test_register_duplicate_email(self):
+        # Register the first user
+        response = self.client.post(self.url, {
+            "email": self.EMAIL,
+            "name": self.NAME,
+            "username": self.USERNAME,
+            "password": self.PASSWORD,
+            "honor_code": "true",
+            "first_name": self.FIRSTNAME,
+            "last_name": self.LASTNAME,
+            "confirm_password": self.PASSWORD,
+            "is_poc": 1,
+            "partners_opt_in": ""
+
+        })
+        self.assertHttpOK(response)
+
+        # Try to create a second user with the same email address
+        response = self.client.post(self.url, {
+            "email": self.EMAIL,
+            "name": "Someone Else",
+            "username": "someone_else",
+            "password": self.PASSWORD,
+            "honor_code": "true",
+            "first_name": self.FIRSTNAME,
+            "last_name": self.LASTNAME,
+            "confirm_password": self.PASSWORD,
+            "is_poc": 1,
+            "partners_opt_in": ""
+
+        })
+        self.assertEqual(response.status_code, 409)
+        response_json = json.loads(response.content)
+        self.assertEqual(
+            response_json,
+            {
+                "email": [{
+                    "user_message": (
+                        "It looks like {} belongs to an existing account. "
+                        "Try again with a different email address."
+                    ).format(
+                        self.EMAIL
+                    )
+                }]
+            }
+        )
+
+    def test_register_duplicate_username(self):
+        # Register the first user
+        response = self.client.post(self.url, {
+            "email": self.EMAIL,
+            "name": self.NAME,
+            "username": self.USERNAME,
+            "password": self.PASSWORD,
+            "honor_code": "true",
+            "first_name": self.FIRSTNAME,
+            "last_name": self.LASTNAME,
+            "confirm_password": self.PASSWORD,
+            "is_poc": 1,
+            "partners_opt_in": ""
+
+        })
+        self.assertHttpOK(response)
+
+        # Try to create a second user with the same username
+        response = self.client.post(self.url, {
+            "email": "someone+else@example.com",
+            "name": "Someone Else",
+            "username": self.USERNAME,
+            "password": self.PASSWORD,
+            "honor_code": "true",
+            "first_name": self.FIRSTNAME,
+            "last_name": self.LASTNAME,
+            "confirm_password": self.PASSWORD,
+            "is_poc": 1,
+            "partners_opt_in": ""
+        })
+        self.assertEqual(response.status_code, 409)
+        response_json = json.loads(response.content)
+        self.assertEqual(
+            response_json,
+            {
+                "username": [{
+                    "user_message": "The username you entered is already being used. Please enter another username."                    
+                }]
+            }
+        )
+
+    def test_register_duplicate_username_and_email(self):
+        # Register the first user
+        response = self.client.post(self.url, {
+            "email": self.EMAIL,
+            "name": self.NAME,
+            "username": self.USERNAME,
+            "password": self.PASSWORD,
+            "honor_code": "true",
+            "first_name": self.FIRSTNAME,
+            "last_name": self.LASTNAME,
+            "confirm_password": self.PASSWORD,
+            "is_poc": 1,
+            "partners_opt_in": ""
+        })
+        self.assertHttpOK(response)
+
+        # Try to create a second user with the same username
+        response = self.client.post(self.url, {
+            "email": self.EMAIL,
+            "name": "Someone Else",
+            "username": self.USERNAME,
+            "password": self.PASSWORD,
+            "honor_code": "true",
+            "first_name": self.FIRSTNAME,
+            "last_name": self.LASTNAME,
+            "confirm_password": self.PASSWORD,
+            "is_poc": 1,
+            "partners_opt_in": ""
+        })
+        self.assertEqual(response.status_code, 409)
+        response_json = json.loads(response.content)
+        self.assertEqual(
+            response_json,
+            {
+                "username": [{
+                    "user_message": "The username you entered is already being used. Please enter another username."                    
+                }],
+                "email": [{
+                    "user_message": (
+                        "It looks like {} belongs to an existing account. "
+                        "Try again with a different email address."
+                    ).format(
+                        self.EMAIL
+                    )
+                }]
+            }
+        )
+
+    @override_settings(REGISTRATION_EXTRA_FIELDS={"honor_code": "hidden", "terms_of_service": "hidden"})
+    def test_register_hidden_honor_code_and_terms_of_service(self):
+        response = self.client.post(self.url, {
+            "email": self.EMAIL,
+            "name": self.NAME,
+            "username": self.USERNAME,
+            "password": self.PASSWORD,
+            "first_name": self.FIRSTNAME,
+            "last_name": self.LASTNAME,
+            "confirm_password": self.PASSWORD,
+            "is_poc": 1,
+            "partners_opt_in": ""
+        })
+        self.assertHttpOK(response)
+
+    def test_missing_fields(self):
+        response = self.client.post(
+            self.url,
+            {
+                "email": self.EMAIL,
+                "name": self.NAME,
+                "honor_code": "true",
+                "first_name": self.FIRSTNAME,
+                "last_name": self.LASTNAME,
+                "confirm_password": self.PASSWORD,
+                "is_poc": 1,
+                "partners_opt_in": ""
+            }
+        )
+        self.assertEqual(response.status_code, 400)
+        response_json = json.loads(response.content)
+        self.assertEqual(
+            response_json,
+            {
+                "username": [{"user_message": "Username must be minimum of two characters long"}],
+                "password": [{"user_message": "A valid password is required"}],
+            }
+        )
+
+    def _assert_reg_field(self, extra_fields_setting, expected_field):
+        """Retrieve the registration form description from the server and
+        verify that it contains the expected field.
+
+        Args:
+            extra_fields_setting (dict): Override the Django setting controlling
+                which extra fields are displayed in the form.
+
+            expected_field (dict): The field definition we expect to find in the form.
+
+        Raises:
+            AssertionError
+
+        """
+        # Add in fields that are always present
+
+
+        defaults = [
+            ("label", ""),
+            ("instructions", ""),
+            ("placeholder", ""),
+            ("defaultValue", ""),
+            ("restrictions", {}),
+            ("errorMessages", {}),
+        ]
+        for key, value in defaults:
+            if key not in expected_field:
+                expected_field[key] = value
+
+
+
+        # Retrieve the registration form description
+        with override_settings(REGISTRATION_EXTRA_FIELDS=extra_fields_setting):
+            response = self.client.get(self.url)
+            self.assertHttpOK(response)
+
+        # Verify that the form description matches what we'd expect
+        form_desc = json.loads(response.content)
+
+        # Search the form for this field
+        actual_field = None
+        for field in form_desc["fields"]:
+            if field["name"] == expected_field["name"]:
+                actual_field = field
+                break
+
+        self.assertIsNot(
+            actual_field, None,
+            msg="Could not find field {name}".format(name=expected_field["name"])
+        )
+
+        for key, value in expected_field.iteritems():
+            self.assertEqual(
+                expected_field[key], actual_field[key],
+                msg=u"Expected {expected} for {key} but got {actual} instead".format(
+                    key=key,
+                    expected=expected_field[key],
+                    actual=actual_field[key]
+                )
+            )
+
+    def test_country_overrides(self):
+        """Test that overridden countries are available in country list."""
+        # Retrieve the registration form description
+        with override_settings(REGISTRATION_EXTRA_FIELDS={"country": "required"}):
+            response = self.client.get(self.url)
+            self.assertHttpOK(response)
+
+        self.assertContains(response, 'Kosovo')
+
+
+@override_settings(
+    MIDDLEWARE_CLASSES=[
+        klass for klass in settings.MIDDLEWARE_CLASSES
+        if klass != 'lms.djangoapps.onboarding.middleware.RedirectMiddleware'
+    ]
+)
+@ddt.ddt
+@skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+class RegistrationViewTestV2(ThirdPartyAuthTestMixin, ApiTestCase):
+    """Tests for the registration version two end-points of the User API. """
+
+    maxDiff = None
+    USERNAME = "bob"
+    EMAIL = "bob@example.com"
+    PASSWORD = "password"
+    NAME = "Bob Smith"
+    FIRSTNAME = "Bob"
+    LASTNAME = "Smith"
+    EDUCATION = "m"
+    YEAR_OF_BIRTH = "1998"
+    ADDRESS = "123 Fake Street"
+    CITY = "Springfield"
+    COUNTRY = "us"
+    GOALS = "Learn all the things!"
+
+    def setUp(self):
+        super(RegistrationViewTestV2, self).setUp()
+        self.url = reverse("user_api_registration_v2")
+
+    @ddt.data("get", "post")
+    def test_auth_disabled(self, method):
+        self.assertAuthDisabled(method, self.url)
+
+    def test_allowed_methods(self):
+        self.assertAllowedMethods(self.url, ["GET", "POST", "HEAD", "OPTIONS"])
+
+    def test_put_not_allowed(self):
+        response = self.client.put(self.url)
+        self.assertHttpMethodNotAllowed(response)
+
+    def test_delete_not_allowed(self):
+        response = self.client.delete(self.url)
+        self.assertHttpMethodNotAllowed(response)
+
+    def test_patch_not_allowed(self):
+        raise SkipTest("Django 1.4's test client does not support patch")
+
+    def test_register_form_default_fields(self):
+        no_extra_fields_setting = {}
+
+        self._assert_reg_field(
+            no_extra_fields_setting,
+            {
+                u"name": u"email",
+                u"type": u"email",
+                u"required": True,
+                u"label": u"Email",
+                u"placeholder": u"username@domain.com",
+                u"restrictions": {
+                    "min_length": EMAIL_MIN_LENGTH,
+                    "max_length": EMAIL_MAX_LENGTH
+                },
+                u"errorMessages": {
+                    u"email": u"The email you entered is not valid. Please provide"
+                    u" a valid email in order to create an account."
+                }
+            }
+        )
+
+
+        self._assert_reg_field(
+            no_extra_fields_setting,
+            {
+                u"name": u"username",
+                u"type": u"text",
+                u"required": True,
+                u"label": u"Public Username",
+                u"placeholder": u"Public Username",
+                u"instructions": u"The name that will identify you in your courses - <strong>(cannot be changed later)</strong>",  # pylint: disable=line-too-long
+                u"restrictions": {
+                    "min_length": USERNAME_MIN_LENGTH,
+                    "max_length": USERNAME_MAX_LENGTH
+                },
+            }
+        )
+
+        self._assert_reg_field(
+            no_extra_fields_setting,
+            {
+                u"placeholder": "Password",
+                u"name": u"password",
+                u"type": u"password",
+                u"required": True,
+                u"label": u"Password",
+                u"restrictions": {
+                    'min_length': PASSWORD_MIN_LENGTH,
+                    'max_length': PASSWORD_MAX_LENGTH
+                },
+            }
+        )
+
+    def _assert_reg_field(self, extra_fields_setting, expected_field):
+        """Retrieve the registration form description from the server and
+        verify that it contains the expected field.
+
+        Args:
+            extra_fields_setting (dict): Override the Django setting controlling
+                which extra fields are displayed in the form.
+
+            expected_field (dict): The field definition we expect to find in the form.
+
+        Raises:
+            AssertionError
+
+        """
+        # Add in fields that are always present
+
+
+        defaults = [
+            ("label", ""),
+            ("instructions", ""),
+            ("placeholder", ""),
+            ("defaultValue", ""),
+            ("restrictions", {}),
+            ("errorMessages", {}),
+        ]
+        for key, value in defaults:
+            if key not in expected_field:
+                expected_field[key] = value
+
+        # Retrieve the registration form description
+        with override_settings(REGISTRATION_EXTRA_FIELDS=extra_fields_setting):
+            response = self.client.get(self.url)
+            self.assertHttpOK(response)
+
+        # Verify that the form description matches what we'd expect
+        form_desc = json.loads(response.content)
+
+        # Search the form for this field
+        actual_field = None
+        for field in form_desc["fields"]:
+            if field["name"] == expected_field["name"]:
+                actual_field = field
+                break
+
+        self.assertIsNot(
+            actual_field, None,
+            msg="Could not find field {name}".format(name=expected_field["name"])
+        )
+
+        for key, value in expected_field.iteritems():
+            self.assertEqual(
+                expected_field[key], actual_field[key],
+                msg=u"Expected {expected} for {key} but got {actual} instead".format(
+                    key=key,
+                    expected=expected_field[key],
+                    actual=actual_field[key]
+                )
+            )
+    
+    def test_register_form_level_of_education(self):
+        self._assert_reg_field(
+            {"level_of_education": "optional"},
+            {
+                "name": "level_of_education",
+                "type": "select",
+                "required": False,
+                "label": "Highest level of education completed",
+                "options": [
+                    {"value": "", "name": "--", "default": True},
+                    {"value": "p", "name": "Doctorate"},
+                    {"value": "m", "name": "Master's or professional degree"},
+                    {"value": "b", "name": "Bachelor's degree"},
+                    {"value": "a", "name": "Associate degree"},
+                    {"value": "hs", "name": "Secondary/high school"},
+                    {"value": "jhs", "name": "Junior secondary/junior high/middle school"},
+                    {"value": "el", "name": "Elementary/primary school"},
+                    {"value": "none", "name": "No formal education"},
+                    {"value": "other", "name": "Other education"},
+                ],
+            }
+        )
+
+    @mock.patch('util.enterprise_helpers.active_provider_requests_data_sharing')
+    @mock.patch('util.enterprise_helpers.active_provider_enforces_data_sharing')
+    @mock.patch('util.enterprise_helpers.get_enterprise_customer_for_request')
+    @mock.patch('util.enterprise_helpers.configuration_helpers')
+    def test_register_form_consent_field(self, config_helper, get_ec, mock_enforce, mock_request):
+        """
+        Test that if we have an EnterpriseCustomer active for the request, and that
+        EnterpriseCustomer is set to require data sharing consent, the correct
+        field is added to the form descriptor.
+        """
+        fake_ec = mock.MagicMock(
+            enforces_data_sharing_consent=mock.MagicMock(return_value=True),
+            requests_data_sharing_consent=True,
+        )
+        fake_ec.name = 'MegaCorp'
+        get_ec.return_value = fake_ec
+        config_helper.get_value.return_value = 'OpenEdX'
+        mock_request.return_value = True
+        mock_enforce.return_value = True
+        self._assert_reg_field(
+            dict(),
+            {
+                u"name": u"data_sharing_consent",
+                u"type": u"checkbox",
+                u"required": True,
+                u"label": (
+                    "I agree to allow OpenEdX to share data about my enrollment, "
+                    "completion and performance in all OpenEdX courses and programs "
+                    "where my enrollment is sponsored by MegaCorp."
+                ),
+                u"defaultValue": False,
+                u"errorMessages": {
+                    u'required': u'To link your account with MegaCorp, you are required to consent to data sharing.',
+                }
+            }
+        )
+
+    @mock.patch('openedx.core.djangoapps.user_api.views._')
+    def test_register_form_level_of_education_translations(self, fake_gettext):
+        fake_gettext.side_effect = lambda text: text + ' TRANSLATED'
+
+        self._assert_reg_field(
+            {"level_of_education": "optional"},
+            {
+                "name": "level_of_education",
+                "type": "select",
+                "required": False,
+                "label": "Highest level of education completed TRANSLATED",
+                "options": [
+                    {"value": "", "name": "--", "default": True},
+                    {"value": "p", "name": "Doctorate TRANSLATED"},
+                    {"value": "m", "name": "Master's or professional degree TRANSLATED"},
+                    {"value": "b", "name": "Bachelor's degree TRANSLATED"},
+                    {"value": "a", "name": "Associate degree TRANSLATED"},
+                    {"value": "hs", "name": "Secondary/high school TRANSLATED"},
+                    {"value": "jhs", "name": "Junior secondary/junior high/middle school TRANSLATED"},
+                    {"value": "el", "name": "Elementary/primary school TRANSLATED"},
+                    {"value": "none", "name": "No formal education TRANSLATED"},
+                    {"value": "other", "name": "Other education TRANSLATED"},
+                ],
+            }
+        )
+
+    def test_register_form_gender(self):
+        self._assert_reg_field(
+            {"gender": "optional"},
+            {
+                "name": "gender",
+                "type": "select",
+                "required": False,
+                "label": "Gender",
+                "options": [
+                    {"value": "", "name": "--", "default": True},
+                    {"value": "m", "name": "Male"},
+                    {"value": "f", "name": "Female"},
+                    {"value": "o", "name": "Other/Prefer Not to Say"},
+                ],
+            }
+        )
+
+    @mock.patch('openedx.core.djangoapps.user_api.views._')
+    def test_register_form_gender_translations(self, fake_gettext):
+        fake_gettext.side_effect = lambda text: text + ' TRANSLATED'
+
+        self._assert_reg_field(
+            {"gender": "optional"},
+            {
+                "name": "gender",
+                "type": "select",
+                "required": False,
+                "label": "Gender TRANSLATED",
+                "options": [
+                    {"value": "", "name": "--", "default": True},
+                    {"value": "m", "name": "Male TRANSLATED"},
+                    {"value": "f", "name": "Female TRANSLATED"},
+                    {"value": "o", "name": "Other/Prefer Not to Say TRANSLATED"},
+                ],
+            }
+        )
+
+    def test_register_form_year_of_birth(self):
+        this_year = datetime.datetime.now(UTC).year
+        year_options = (
+            [{"value": "", "name": "--", "default": True}] + [
+                {"value": unicode(year), "name": unicode(year)}
+                for year in range(this_year, this_year - 120, -1)
+            ]
+        )
+        self._assert_reg_field(
+            {"year_of_birth": "optional"},
+            {
+                "name": "year_of_birth",
+                "type": "select",
+                "required": False,
+                "label": "Year of birth",
+                "options": year_options,
+            }
+        )
+
+    def test_registration_form_mailing_address(self):
+        self._assert_reg_field(
+            {"mailing_address": "optional"},
+            {
+                "name": "mailing_address",
+                "type": "textarea",
+                "required": False,
+                "label": "Mailing address",
+            }
+        )
+
+    def test_registration_form_goals(self):
+        self._assert_reg_field(
+            {"goals": "optional"},
+            {
+                "name": "goals",
+                "type": "textarea",
+                "required": False,
+                "label": u"Tell us why you're interested in {platform_name}".format(
+                    platform_name=settings.PLATFORM_NAME
+                )
+            }
+        )
+
+    def test_registration_form_city(self):
+        self._assert_reg_field(
+            {"city": "optional"},
+            {
+                "name": "city",
+                "type": "text",
+                "required": False,
+                "label": "City",
+            }
+        )
+
+    def test_registration_form_state(self):
+        self._assert_reg_field(
+            {"state": "optional"},
+            {
+                "name": "state",
+                "type": "text",
+                "required": False,
+                "label": "State/Province/Region",
+            }
+        )
+
+    def test_registration_form_country(self):
+        country_options = (
+            [{"name": "--", "value": "", "default": True}] +
+            [
+                {"value": country_code, "name": unicode(country_name)}
+                for country_code, country_name in SORTED_COUNTRIES
+            ]
+        )
+        self._assert_reg_field(
+            {"country": "required"},
+            {
+                "label": "Country",
+                "name": "country",
+                "type": "select",
+                "required": True,
+                "options": country_options,
+                "errorMessages": {
+                    "required": "Please select your Country."
+                },
+            }
+        )
+
+    @override_settings(
+        MKTG_URLS={"ROOT": "https://www.test.com/", "HONOR": "honor"},
+    )
+    @mock.patch.dict(settings.FEATURES, {"ENABLE_MKTG_SITE": True})
+    def test_registration_honor_code_mktg_site_enabled(self):
+        link_label = 'Terms of Service and Honor Code'
+        self._assert_reg_field(
+            {"honor_code": "required"},
+            {
+                "label": u"Check here if you agree to be bound by, and to comply with, our ",
+                "name": "honor_code",
+                "defaultValue": False,
+                "type": "checkbox",
+                "required": True,
+                "errorMessages": {
+                    "required": "Please accept our Terms and Conditions by checking the Terms and Conditions" \
+                    " checkbox before creating an account."
+                }
+            }
+        )
+
+    @override_settings(MKTG_URLS_LINK_MAP={"HONOR": "honor"})
+    @mock.patch.dict(settings.FEATURES, {"ENABLE_MKTG_SITE": False})
+    def test_registration_honor_code_mktg_site_disabled(self):
+        link_label = 'Terms of Service and Honor Code'
+        self._assert_reg_field(
+            {"honor_code": "required"},
+            {
+                "label": u"Check here if you agree to be bound by, and to comply with, our ",
+                "name": "honor_code",
+                "defaultValue": False,
+                "type": "checkbox",
+                "required": True,
+                "errorMessages": {
+                    "required": "Please accept our Terms and Conditions by checking the Terms and Conditions" \
+                    " checkbox before creating an account."
+                }
+            }
+        )
+
+    @override_settings(MKTG_URLS={
+        "ROOT": "https://www.test.com/",
+        "HONOR": "honor",
+        "TOS": "tos",
+    })
+    @mock.patch.dict(settings.FEATURES, {"ENABLE_MKTG_SITE": True})
+    def test_registration_separate_terms_of_service_mktg_site_enabled(self):
+        # Honor code field should say ONLY honor code,
+        # not "terms of service and honor code"
+        link_label = 'Honor Code'
+        self._assert_reg_field(
+            {"honor_code": "required", "terms_of_service": "required"},
+            {
+                "label": u"Check here if you agree to be bound by, and to comply with, our ",
+                "name": "honor_code",
+                "defaultValue": False,
+                "type": "checkbox",
+                "required": True,
+                "errorMessages": {
+                    "required": "Please accept our Terms and Conditions by checking the Terms and Conditions" \
+                    " checkbox before creating an account."
+                }                
+            }
+        )
+
+        # Terms of service field should also be present
+        link_label = 'Terms of Service'
+        self._assert_reg_field(
+            {"honor_code": "required", "terms_of_service": "required"},
+            {
+                "label": u"I agree to the {platform_name} {link_label}".format(
+                    platform_name=settings.PLATFORM_NAME,
+                    link_label=link_label
+                ),
+                "name": "terms_of_service",
+                "defaultValue": False,
+                "type": "checkbox",
+                "required": True,
+                "errorMessages": {
+                    "required": u"You must agree to the {platform_name} {link_label}".format(
+                        platform_name=settings.PLATFORM_NAME,
+                        link_label=link_label
+                    )
+                }
+            }
+        )
+
+    @override_settings(MKTG_URLS_LINK_MAP={"HONOR": "honor", "TOS": "tos"})
+    @mock.patch.dict(settings.FEATURES, {"ENABLE_MKTG_SITE": False})
+    def test_registration_separate_terms_of_service_mktg_site_disabled(self):
+        # Honor code field should say ONLY honor code,
+        # not "terms of service and honor code"
+        self._assert_reg_field(
+            {"honor_code": "required", "terms_of_service": "required"},
+            {
+                "label": u"Check here if you agree to be bound by, and to comply with, our ",
+                "name": "honor_code",
+                "defaultValue": False,
+                "type": "checkbox",
+                "required": True,
+                "errorMessages": {
+                    "required": "Please accept our Terms and Conditions by checking the Terms and Conditions" \
+                    " checkbox before creating an account."
+                }                
+            }
+        )
+
+        # Terms of service field should also be present
+        self._assert_reg_field(
+            {"honor_code": "required", "terms_of_service": "required"},
+            {
+                "label": u"I agree to the {platform_name} Terms of Service".format(
+                    platform_name=settings.PLATFORM_NAME
+                ),
+                "name": "terms_of_service",
+                "defaultValue": False,
+                "type": "checkbox",
+                "required": True,
+                "errorMessages": {
+                    "required": u"You must agree to the {platform_name} Terms of Service".format(  # pylint: disable=line-too-long
+                        platform_name=settings.PLATFORM_NAME
+                    )
+                }
+            }
+        )
+
+    @override_settings(
+        REGISTRATION_EXTRA_FIELDS={
+            "level_of_education": "optional",
+            "gender": "optional",
+            "year_of_birth": "optional",
+            "mailing_address": "optional",
+            "goals": "optional",
+            "city": "optional",
+            "state": "optional",
+            "country": "required",
+            "honor_code": "required",
+        },
+        REGISTRATION_EXTENSION_FORM='openedx.core.djangoapps.user_api.tests.test_helpers.TestCaseForm',
+    )
+    def test_field_order(self):
+        response = self.client.get(self.url)
+        self.assertHttpOK(response)
+
+        # Verify that all fields render in the correct order
+        form_desc = json.loads(response.content)
+        field_names = [field["name"] for field in form_desc["fields"]]
+        self.assertEqual(field_names, [
+            u'email',
+            u'username',
+            u'password',
+            u'confirm_password',
+            u'first_name',
+            u'last_name',
+            u'opt_in',
+            u'city',
+            u'state',
+            u'country',
+            u'gender',
+            u'year_of_birth',
+            u'level_of_education',
+            u'mailing_address',
+            u'goals',
+            u'honor_code'
+        ])
+
+    @factory.django.mute_signals(post_save)
+    def test_register(self):
+        # Create a new registration
+        response = self.client.post(self.url, {
+            "email": self.EMAIL,
+            "name": self.NAME,
+            "username": self.USERNAME,
+            "password": self.PASSWORD,
+            "honor_code": "true",
+            "first_name": self.FIRSTNAME,
+            "last_name": self.LASTNAME,
+            "confirm_password": self.PASSWORD,
+            "is_poc": 1,
+            "partners_opt_in": ""
+        })
+        self.assertHttpOK(response)
+        self.assertIn(settings.EDXMKTG_LOGGED_IN_COOKIE_NAME, self.client.cookies)
+        self.assertIn(settings.EDXMKTG_USER_INFO_COOKIE_NAME, self.client.cookies)
+
+        user = User.objects.get(username=self.USERNAME)
+        request = RequestFactory().get('/url')
+        request.user = user
+        account_settings = get_account_settings(request)[0]
+
+        self.assertEqual(self.USERNAME, account_settings["username"])
+        self.assertEqual(self.EMAIL, account_settings["email"])
+        self.assertFalse(account_settings["is_active"])
+        self.assertEqual(self.NAME, account_settings["name"])
+
+        # Verify that we've been logged in
+        # by trying to access a page that requires authentication
+        response = self.client.get(reverse("learner_profile", kwargs={'username': self.USERNAME}))
+        self.assertHttpOK(response)
+
+    @override_settings(REGISTRATION_EXTRA_FIELDS={
+        "level_of_education": "optional",
+        "gender": "optional",
+        "year_of_birth": "optional",
+        "mailing_address": "optional",
+        "goals": "optional",
+        "country": "required",
+    })
+    @factory.django.mute_signals(post_save)
+    def test_register_with_profile_info(self):
+        # Register, providing lots of demographic info
+        response = self.client.post(self.url, {
+            "email": self.EMAIL,
+            "name": self.NAME,
+            "username": self.USERNAME,
+            "password": self.PASSWORD,
+            "level_of_education": self.EDUCATION,
+            "mailing_address": self.ADDRESS,
+            "year_of_birth": self.YEAR_OF_BIRTH,
+            "goals": self.GOALS,
+            "country": self.COUNTRY,
+            "honor_code": "true",
+            "first_name": self.FIRSTNAME,
+            "last_name": self.LASTNAME,
+            "confirm_password": self.PASSWORD,
+            "is_poc": 1,
+            "partners_opt_in": ""
+        })
+        self.assertHttpOK(response)
+
+        # Verify the user's account
+        user = User.objects.get(username=self.USERNAME)
+        request = RequestFactory().get('/url')
+        request.user = user
+        account_settings = get_account_settings(request)[0]
+
+        self.assertEqual(account_settings["level_of_education"], self.EDUCATION)
+        self.assertEqual(account_settings["mailing_address"], self.ADDRESS)
+        self.assertEqual(account_settings["year_of_birth"], int(self.YEAR_OF_BIRTH))
+        self.assertEqual(account_settings["goals"], self.GOALS)
+        self.assertEqual(account_settings["country"], self.COUNTRY)
+
+    @mock.patch('mailchimp_pipeline.signals.handlers.task_send_account_activation_email')
+    @factory.django.mute_signals(post_save)    
+    def test_activation_email(self, mock_func):
+        # Register, which should trigger an activation email
+        response = self.client.post(self.url, {
+            "email": self.EMAIL,
+            "name": self.NAME,
+            "username": self.USERNAME,
+            "password": self.PASSWORD,
+            "honor_code": "true",
+            "first_name": self.FIRSTNAME,
+            "last_name": self.LASTNAME,
+            "confirm_password": self.PASSWORD,
+            "is_poc": 1,
+            "partners_opt_in": ""
+        })
+        self.assertHttpOK(response)
+
+        # Verify that the activation email was sent
+        mock_func.assert_called_once()
+
+    @ddt.data(
+        {"email": ""},
+        {"email": "invalid"},
+        {"first_name": ""},
+        {"last_name": ""},
+        {"username": ""},
+        {"username": "a"},
+        {"password": ""},
+    )
+    def test_register_invalid_input(self, invalid_fields):
+        # Initially, the field values are all valid
+        data = {
+            "email": self.EMAIL,
+            "name": self.NAME,
+            "username": self.USERNAME,
+            "password": self.PASSWORD,
+            "honor_code": "true",
+            "first_name": self.FIRSTNAME,
+            "last_name": self.LASTNAME,
+            "confirm_password": self.PASSWORD,
+            "is_poc": 1,
+            "partners_opt_in": ""
+        }
+        # Override the valid fields, making the input invalid
+        data.update(invalid_fields)
+
+        # Attempt to create the account, expecting an error response
+        response = self.client.post(self.url, data)
+        self.assertHttpBadRequest(response)
+
+    @override_settings(REGISTRATION_EXTRA_FIELDS={"country": "required"})
+    @ddt.data("email", "username", "password", "country", ("first_name", "last_name"))
+    def test_register_missing_required_field(self, missing_field):
+        data = {
+            "email": self.EMAIL,
+            "name": self.NAME,
+            "username": self.USERNAME,
+            "password": self.PASSWORD,
+            "country": self.COUNTRY,
+            "honor_code": "true",
+            "first_name": self.FIRSTNAME,
+            "last_name": self.LASTNAME,
+            "confirm_password": self.PASSWORD,
+            "is_poc": 1,
+            "partners_opt_in": ""
+        }
+
+        if isinstance(missing_field, tuple):
+            for key in missing_field:
+                del data[key]
+        else:
+            del data[missing_field]
+
+        # Send a request missing a field
+        response = self.client.post(self.url, data)
+        self.assertHttpBadRequest(response)
+
+    def test_register_duplicate_email(self):
+        # Register the first user
+        response = self.client.post(self.url, {
+            "email": self.EMAIL,
+            "name": self.NAME,
+            "username": self.USERNAME,
+            "password": self.PASSWORD,
+            "honor_code": "true",
+            "first_name": self.FIRSTNAME,
+            "last_name": self.LASTNAME,
+            "confirm_password": self.PASSWORD,
+            "is_poc": 1,
+            "partners_opt_in": ""
+
+        })
+        self.assertHttpOK(response)
+
+        # Try to create a second user with the same email address
+        response = self.client.post(self.url, {
+            "email": self.EMAIL,
+            "name": "Someone Else",
+            "username": "someone_else",
+            "password": self.PASSWORD,
+            "honor_code": "true",
+            "first_name": self.FIRSTNAME,
+            "last_name": self.LASTNAME,
+            "confirm_password": self.PASSWORD,
+            "is_poc": 1,
+            "partners_opt_in": ""
+
+        })
+        self.assertEqual(response.status_code, 409)
+        response_json = json.loads(response.content)
+        self.assertEqual(
+            response_json,
+            {
+                "email": [{
+                    "user_message": (
+                        "It looks like {} belongs to an existing account. "
+                        "Try again with a different email address."
+                    ).format(
+                        self.EMAIL
+                    )
+                }]
+            }
+        )
+
+    def test_register_duplicate_username(self):
+        # Register the first user
+        response = self.client.post(self.url, {
+            "email": self.EMAIL,
+            "name": self.NAME,
+            "username": self.USERNAME,
+            "password": self.PASSWORD,
+            "honor_code": "true",
+            "first_name": self.FIRSTNAME,
+            "last_name": self.LASTNAME,
+            "confirm_password": self.PASSWORD,
+            "is_poc": 1,
+            "partners_opt_in": ""
+
+        })
+        self.assertHttpOK(response)
+
+        # Try to create a second user with the same username
+        response = self.client.post(self.url, {
+            "email": "someone+else@example.com",
+            "name": "Someone Else",
+            "username": self.USERNAME,
+            "password": self.PASSWORD,
+            "honor_code": "true",
+            "first_name": self.FIRSTNAME,
+            "last_name": self.LASTNAME,
+            "confirm_password": self.PASSWORD,
+            "is_poc": 1,
+            "partners_opt_in": ""
+        })
+        self.assertEqual(response.status_code, 409)
+        response_json = json.loads(response.content)
+        self.assertEqual(
+            response_json,
+            {
+                "username": [{
+                    "user_message": "The username you entered is already being used. Please enter another username."                    
+                }]
+            }
+        )
+
+    def test_register_duplicate_username_and_email(self):
+        # Register the first user
+        response = self.client.post(self.url, {
+            "email": self.EMAIL,
+            "name": self.NAME,
+            "username": self.USERNAME,
+            "password": self.PASSWORD,
+            "honor_code": "true",
+            "first_name": self.FIRSTNAME,
+            "last_name": self.LASTNAME,
+            "confirm_password": self.PASSWORD,
+            "is_poc": 1,
+            "partners_opt_in": ""
+        })
+        self.assertHttpOK(response)
+
+        # Try to create a second user with the same username
+        response = self.client.post(self.url, {
+            "email": self.EMAIL,
+            "name": "Someone Else",
+            "username": self.USERNAME,
+            "password": self.PASSWORD,
+            "honor_code": "true",
+            "first_name": self.FIRSTNAME,
+            "last_name": self.LASTNAME,
+            "confirm_password": self.PASSWORD,
+            "is_poc": 1,
+            "partners_opt_in": ""
+        })
+        self.assertEqual(response.status_code, 409)
+        response_json = json.loads(response.content)
+        self.assertEqual(
+            response_json,
+            {
+                "username": [{
+                    "user_message": "The username you entered is already being used. Please enter another username."                    
+                }],
+                "email": [{
+                    "user_message": (
+                        "It looks like {} belongs to an existing account. "
+                        "Try again with a different email address."
+                    ).format(
+                        self.EMAIL
+                    )
+                }]
+            }
+        )
+
+    @override_settings(REGISTRATION_EXTRA_FIELDS={"honor_code": "hidden", "terms_of_service": "hidden"})
+    def test_register_hidden_honor_code_and_terms_of_service(self):
+        response = self.client.post(self.url, {
+            "email": self.EMAIL,
+            "name": self.NAME,
+            "username": self.USERNAME,
+            "password": self.PASSWORD,
+            "first_name": self.FIRSTNAME,
+            "last_name": self.LASTNAME,
+            "confirm_password": self.PASSWORD,
+            "is_poc": 1,
+            "partners_opt_in": ""
+        })
+        self.assertHttpOK(response)
+
+    def test_missing_fields(self):
+        response = self.client.post(
+            self.url,
+            {
+                "email": self.EMAIL,
+                "name": self.NAME,
+                "honor_code": "true",
+                "first_name": self.FIRSTNAME,
+                "last_name": self.LASTNAME,
+                "confirm_password": self.PASSWORD,
+                "is_poc": 1,
+                "partners_opt_in": ""
+            }
+        )
+        self.assertEqual(response.status_code, 400)
+        response_json = json.loads(response.content)
+        self.assertEqual(
+            response_json,
+            {
+                "username": [{"user_message": "Username must be minimum of two characters long"}],
+                "password": [{"user_message": "A valid password is required"}],
+            }
+        )
+
+    def test_country_overrides(self):
+        """Test that overridden countries are available in country list."""
+        # Retrieve the registration form description
+        with override_settings(REGISTRATION_EXTRA_FIELDS={"country": "required"}):
+            response = self.client.get(self.url)
+            self.assertHttpOK(response)
+
+        self.assertContains(response, 'Kosovo')

--- a/lms/djangoapps/philu_overrides/user_api/tests/test_views.py
+++ b/lms/djangoapps/philu_overrides/user_api/tests/test_views.py
@@ -2,48 +2,35 @@
 
 import datetime
 import json
+from unittest import SkipTest, skipUnless
+
 import ddt
 import factory
 import httpretty
 import mock
-
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.core import mail
 from django.core.urlresolvers import reverse
-from django.db import IntegrityError
 from django.db.models.signals import post_save
 from django.test.client import RequestFactory
 from django.test.testcases import TransactionTestCase
 from django.test.utils import override_settings
-from django.utils.importlib import import_module
-from opaque_keys.edx.locations import SlashSeparatedCourseKey
-from pytz import UTC, common_timezones_set
+from pytz import UTC
 from social.apps.django_app.default.models import UserSocialAuth
-from unittest import SkipTest, skipUnless
+from third_party_auth.tests.testutil import ThirdPartyAuthTestMixin
+from third_party_auth.tests.utils import (ThirdPartyOAuthTestMixin, ThirdPartyOAuthTestMixinFacebook,
+                                          ThirdPartyOAuthTestMixinGoogle)
 
-from common.djangoapps.nodebb.signals.handlers import sync_extended_profile_info_with_nodebb
-from common.djangoapps.student.views import AccountValidationError
-from django_comment_common import models
-from lms.djangoapps.onboarding.models import UserExtendedProfile
 from lms.djangoapps.onboarding.tests.factories import UserFactory
 from lms.djangoapps.philu_overrides.user_api.views import RegistrationViewCustom
-from openedx.core.djangoapps.external_auth.models import ExternalAuthMap
 from openedx.core.djangoapps.user_api.accounts import (EMAIL_MAX_LENGTH, EMAIL_MIN_LENGTH,
-    NAME_MAX_LENGTH, PASSWORD_MAX_LENGTH, PASSWORD_MIN_LENGTH, USERNAME_MAX_LENGTH, USERNAME_MIN_LENGTH)
+                                                       PASSWORD_MAX_LENGTH, PASSWORD_MIN_LENGTH, USERNAME_MAX_LENGTH,
+                                                       USERNAME_MIN_LENGTH)
 from openedx.core.djangoapps.user_api.accounts.api import get_account_settings
 from openedx.core.djangoapps.user_api.tests.test_constants import SORTED_COUNTRIES
 from openedx.core.djangoapps.user_api.tests.test_helpers import TestCaseForm
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase
-from openedx.core.lib.api.test_utils import TEST_API_KEY, ApiTestCase
-from openedx.core.lib.time_zone_utils import get_display_time_zone
-from student.forms import AccountCreationForm, get_registration_extension_form
-from third_party_auth.tests.testutil import ThirdPartyAuthTestMixin
-from third_party_auth.tests.utils import (ThirdPartyOAuthTestMixin, ThirdPartyOAuthTestMixinFacebook, 
-    ThirdPartyOAuthTestMixinGoogle)
-from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory
-
+from openedx.core.lib.api.test_utils import ApiTestCase
 from .utils import simulate_running_pipeline, mocked_registration_view_post_method
 
 
@@ -207,7 +194,7 @@ class LoginSessionViewTest(ApiTestCase):
             "password": self.PASSWORD,
         })
         self.assertHttpForbidden(response)
-    
+
     @factory.django.mute_signals(post_save)
     def test_missing_login_params(self):
         # Create a test user
@@ -295,7 +282,7 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, ApiTestCase):
                 },
                 u"errorMessages": {
                     u"email": u"The email you entered is not valid. Please provide"
-                    u" a valid email in order to create an account."
+                              u" a valid email in order to create an account."
                 }
             }
         )
@@ -308,7 +295,8 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, ApiTestCase):
                 u"required": True,
                 u"label": u"Public Username",
                 u"placeholder": u"Public Username",
-                u"instructions": u"The name that will identify you in your courses - <strong>(cannot be changed later)</strong>",  # pylint: disable=line-too-long
+                u"instructions": u"The name that will identify you in your courses - <strong>(cannot be changed later)</strong>",
+                # pylint: disable=line-too-long
                 u"restrictions": {
                     "min_length": USERNAME_MIN_LENGTH,
                     "max_length": USERNAME_MAX_LENGTH
@@ -333,7 +321,7 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, ApiTestCase):
 
     @override_settings(
         REGISTRATION_EXTENSION_FORM='openedx.core.djangoapps.user_api.tests.test_helpers.TestCaseForm'
-        )
+    )
     def test_extension_form_fields(self):
         no_extra_fields_setting = {}
 
@@ -352,7 +340,7 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, ApiTestCase):
                 },
                 u"errorMessages": {
                     u"email": u"The email you entered is not valid. Please provide"
-                    u" a valid email in order to create an account."
+                              u" a valid email in order to create an account."
                 }
             }
         )
@@ -398,9 +386,9 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, ApiTestCase):
 
         self.configure_google_provider(enabled=True)
         with simulate_running_pipeline(
-            "openedx.core.djangoapps.user_api.views.third_party_auth.pipeline",
-            "google-oauth2", email="bob@example.com",
-            fullname="Bob", username="Bob123"
+                "openedx.core.djangoapps.user_api.views.third_party_auth.pipeline",
+                "google-oauth2", email="bob@example.com",
+                fullname="Bob", username="Bob123"
         ):
             # Password field should be hidden
             self._assert_reg_field(
@@ -434,7 +422,7 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, ApiTestCase):
                     },
                     u"errorMessages": {
                         u"email": u"The email you entered is not valid. Please provide"
-                        u" a valid email in order to create an account."
+                                  u" a valid email in order to create an account."
                     }
                 }
             )
@@ -479,7 +467,8 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, ApiTestCase):
                     u"required": True,
                     u"label": u"Public Username",
                     u"placeholder": u"Public Username",
-                    u"instructions": u"The name that will identify you in your courses - <strong>(cannot be changed later)</strong>",  # pylint: disable=line-too-long
+                    u"instructions": u"The name that will identify you in your courses - <strong>(cannot be changed later)</strong>",
+                    # pylint: disable=line-too-long
                     u"restrictions": {
                         "min_length": USERNAME_MIN_LENGTH,
                         "max_length": USERNAME_MAX_LENGTH
@@ -613,10 +602,10 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, ApiTestCase):
     def test_register_form_year_of_birth(self):
         this_year = datetime.datetime.now(UTC).year
         year_options = (
-            [{"value": "", "name": "--", "default": True}] + [
-                {"value": unicode(year), "name": unicode(year)}
-                for year in range(this_year, this_year - 120, -1)
-            ]
+                [{"value": "", "name": "--", "default": True}] + [
+            {"value": unicode(year), "name": unicode(year)}
+            for year in range(this_year, this_year - 120, -1)
+        ]
         )
         self._assert_reg_field(
             {"year_of_birth": "optional"},
@@ -677,11 +666,11 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, ApiTestCase):
 
     def test_registration_form_country(self):
         country_options = (
-            [{"name": "--", "value": "", "default": True}] +
-            [
-                {"value": country_code, "name": unicode(country_name)}
-                for country_code, country_name in SORTED_COUNTRIES
-            ]
+                [{"name": "--", "value": "", "default": True}] +
+                [
+                    {"value": country_code, "name": unicode(country_name)}
+                    for country_code, country_name in SORTED_COUNTRIES
+                ]
         )
         self._assert_reg_field(
             {"country": "required"},
@@ -713,7 +702,7 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, ApiTestCase):
                 "required": True,
                 "errorMessages": {
                     "required": "Please accept our Terms and Conditions by checking the Terms and Conditions" \
-                    " checkbox before creating an account."
+                                " checkbox before creating an account."
                 }
             }
         )
@@ -732,7 +721,7 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, ApiTestCase):
                 "required": True,
                 "errorMessages": {
                     "required": "Please accept our Terms and Conditions by checking the Terms and Conditions" \
-                    " checkbox before creating an account."
+                                " checkbox before creating an account."
                 }
             }
         )
@@ -757,8 +746,8 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, ApiTestCase):
                 "required": True,
                 "errorMessages": {
                     "required": "Please accept our Terms and Conditions by checking the Terms and Conditions" \
-                    " checkbox before creating an account."
-                }                
+                                " checkbox before creating an account."
+                }
             }
         )
 
@@ -799,8 +788,8 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, ApiTestCase):
                 "required": True,
                 "errorMessages": {
                     "required": "Please accept our Terms and Conditions by checking the Terms and Conditions" \
-                    " checkbox before creating an account."
-                }                
+                                " checkbox before creating an account."
+                }
             }
         )
 
@@ -816,7 +805,8 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, ApiTestCase):
                 "type": "checkbox",
                 "required": True,
                 "errorMessages": {
-                    "required": u"You must agree to the {platform_name} Terms of Service".format(  # pylint: disable=line-too-long
+                    "required": u"You must agree to the {platform_name} Terms of Service".format(
+                        # pylint: disable=line-too-long
                         platform_name=settings.PLATFORM_NAME
                     )
                 }
@@ -938,7 +928,7 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, ApiTestCase):
         self.assertEqual(account_settings["country"], self.COUNTRY)
 
     @mock.patch('mailchimp_pipeline.signals.handlers.task_send_account_activation_email')
-    @factory.django.mute_signals(post_save)    
+    @factory.django.mute_signals(post_save)
     def test_activation_email(self, mock_func):
         # Register, which should trigger an activation email
         response = self.client.post(self.url, {
@@ -1098,7 +1088,7 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, ApiTestCase):
             response_json,
             {
                 "username": [{
-                    "user_message": "The username you entered is already being used. Please enter another username."                    
+                    "user_message": "The username you entered is already being used. Please enter another username."
                 }]
             }
         )
@@ -1138,7 +1128,7 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, ApiTestCase):
             response_json,
             {
                 "username": [{
-                    "user_message": "The username you entered is already being used. Please enter another username."                    
+                    "user_message": "The username you entered is already being used. Please enter another username."
                 }],
                 "email": [{
                     "user_message": (
@@ -1289,11 +1279,6 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, ApiTestCase):
         })
 
 
-    
-    
-
-
-
 class RegistrationViewTestV2(RegistrationViewTest):
     """Tests for the registration version two end-points of the User API. """
 
@@ -1338,7 +1323,7 @@ class RegistrationViewTestV2(RegistrationViewTest):
             u"level_of_education",
             u"mailing_address",
             u"goals",
-            u"honor_code"        
+            u"honor_code"
         ])
 
     def test_extension_form_fields(self):
@@ -1413,13 +1398,13 @@ class ThirdPartyRegistrationTestMixin(ThirdPartyOAuthTestMixin, CacheIsolationTe
             )
         else:
             self.assertEquals(UserSocialAuth.objects.count(), 0)
-    
-    @factory.django.mute_signals(post_save)    
+
+    @factory.django.mute_signals(post_save)
     def test_success(self):
         with simulate_running_pipeline(
-            "lms.djangoapps.philu_overrides.user_api.views.pipeline",
-            self.BACKEND
-        ): 
+                "lms.djangoapps.philu_overrides.user_api.views.pipeline",
+                self.BACKEND
+        ):
             self._verify_user_existence(user_exists=False, social_link_exists=False)
 
             self._setup_provider_response(success=True)
@@ -1428,12 +1413,12 @@ class ThirdPartyRegistrationTestMixin(ThirdPartyOAuthTestMixin, CacheIsolationTe
 
             self._verify_user_existence(user_exists=True, social_link_exists=True, user_is_active=False)
 
-    @factory.django.mute_signals(post_save)    
+    @factory.django.mute_signals(post_save)
     def test_unlinked_active_user(self):
         with simulate_running_pipeline(
-            "lms.djangoapps.philu_overrides.user_api.views.pipeline",
-            self.BACKEND
-        ): 
+                "lms.djangoapps.philu_overrides.user_api.views.pipeline",
+                self.BACKEND
+        ):
             user = UserFactory()
             response = self.client.post(self.url, self.data(user))
             self._assert_existing_user_error(response)
@@ -1441,12 +1426,12 @@ class ThirdPartyRegistrationTestMixin(ThirdPartyOAuthTestMixin, CacheIsolationTe
                 user_exists=True, social_link_exists=False, user_is_active=True, username=user.username
             )
 
-    @factory.django.mute_signals(post_save)    
+    @factory.django.mute_signals(post_save)
     def test_unlinked_inactive_user(self):
         with simulate_running_pipeline(
-            "lms.djangoapps.philu_overrides.user_api.views.pipeline",
-            self.BACKEND
-        ):         
+                "lms.djangoapps.philu_overrides.user_api.views.pipeline",
+                self.BACKEND
+        ):
             user = UserFactory(is_active=False)
             response = self.client.post(self.url, self.data(user))
             self._assert_existing_user_error(response)
@@ -1454,12 +1439,12 @@ class ThirdPartyRegistrationTestMixin(ThirdPartyOAuthTestMixin, CacheIsolationTe
                 user_exists=True, social_link_exists=False, user_is_active=False, username=user.username
             )
 
-    @factory.django.mute_signals(post_save)    
+    @factory.django.mute_signals(post_save)
     def test_user_already_registered(self):
         with simulate_running_pipeline(
-            "lms.djangoapps.philu_overrides.user_api.views.pipeline",
-            self.BACKEND
-        ):             
+                "lms.djangoapps.philu_overrides.user_api.views.pipeline",
+                self.BACKEND
+        ):
             self._setup_provider_response(success=True)
             user = UserFactory()
             UserSocialAuth.objects.create(user=user, provider=self.BACKEND, uid=self.social_uid)
@@ -1469,39 +1454,39 @@ class ThirdPartyRegistrationTestMixin(ThirdPartyOAuthTestMixin, CacheIsolationTe
                 user_exists=True, social_link_exists=True, user_is_active=True, username=user.username
             )
 
-    
-    @factory.django.mute_signals(post_save)    
+    @factory.django.mute_signals(post_save)
     def test_social_user_conflict(self):
         with simulate_running_pipeline(
-            "lms.djangoapps.philu_overrides.user_api.views.pipeline",
-            self.BACKEND
-        ):             
+                "lms.djangoapps.philu_overrides.user_api.views.pipeline",
+                self.BACKEND
+        ):
             self._setup_provider_response(success=True)
             user = UserFactory()
             UserSocialAuth.objects.create(user=user, provider=self.BACKEND, uid=self.social_uid)
             response = self.client.post(self.url, self.data())
-            self._assert_access_token_error(response, "The provided access_token is already associated with another user.")
+            self._assert_access_token_error(response,
+                                            "The provided access_token is already associated with another user.")
             self._verify_user_existence(
                 user_exists=True, social_link_exists=True, user_is_active=True, username=user.username
             )
 
-    @factory.django.mute_signals(post_save)    
+    @factory.django.mute_signals(post_save)
     def test_invalid_token(self):
         with simulate_running_pipeline(
-            "lms.djangoapps.philu_overrides.user_api.views.pipeline",
-            self.BACKEND
-        ): 
+                "lms.djangoapps.philu_overrides.user_api.views.pipeline",
+                self.BACKEND
+        ):
             self._setup_provider_response(success=False)
             response = self.client.post(self.url, self.data())
             self._assert_access_token_error(response, "The provided access_token is not valid.")
             self._verify_user_existence(user_exists=False, social_link_exists=False)
 
-    @factory.django.mute_signals(post_save)    
+    @factory.django.mute_signals(post_save)
     def test_missing_token(self):
         with simulate_running_pipeline(
-            "lms.djangoapps.philu_overrides.user_api.views.pipeline",
-            self.BACKEND
-        ): 
+                "lms.djangoapps.philu_overrides.user_api.views.pipeline",
+                self.BACKEND
+        ):
             data = self.data()
             data.pop("access_token")
             response = self.client.post(self.url, data)
@@ -1531,11 +1516,12 @@ class TestFacebookRegistrationView(
 
 
 @skipUnless(settings.FEATURES.get("ENABLE_THIRD_PARTY_AUTH"), "third party auth not enabled")
-class TestGoogleRegistrationView( 
+class TestGoogleRegistrationView(
     ThirdPartyRegistrationTestMixin, ThirdPartyOAuthTestMixinGoogle, TransactionTestCase
 ):
     """Tests the User API registration version one endpoint with Google authentication."""
     __test__ = True
+
 
 class ThirdPartyRegistrationTestMixinV2(ThirdPartyRegistrationTestMixin):
     """Tests for the registration version two end-points of the User API. """

--- a/lms/djangoapps/philu_overrides/user_api/tests/test_views.py
+++ b/lms/djangoapps/philu_overrides/user_api/tests/test_views.py
@@ -1328,7 +1328,7 @@ class RegistrationViewTestV2(RegistrationViewTest):
         ])
 
     def test_extension_form_fields(self):
-        raise SkipTest("RegisterationView Versioi2 doesn't support this test")
+        raise SkipTest("RegisterationView Version 2 doesn't support this test")
 
 
 @httpretty.activate

--- a/lms/djangoapps/philu_overrides/user_api/tests/test_views.py
+++ b/lms/djangoapps/philu_overrides/user_api/tests/test_views.py
@@ -329,7 +329,9 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, ApiTestCase):
             }
         )
 
-    @override_settings(REGISTRATION_EXTENSION_FORM='openedx.core.djangoapps.user_api.tests.test_helpers.TestCaseForm')
+    @override_settings(
+        REGISTRATION_EXTENSION_FORM='openedx.core.djangoapps.user_api.tests.test_helpers.TestCaseForm'
+        )
     def test_extension_form_fields(self):
         no_extra_fields_setting = {}
 
@@ -1283,22 +1285,22 @@ class RegistrationViewTestV2(RegistrationViewTest):
         form_desc = json.loads(response.content)
         field_names = [field["name"] for field in form_desc["fields"]]
         self.assertEqual(field_names, [
-            u'email',
-            u'username',
-            u'password',
-            u'confirm_password',
-            u'first_name',
-            u'last_name',
-            u'opt_in',
-            u'city',
-            u'state',
-            u'country',
-            u'gender',
-            u'year_of_birth',
-            u'level_of_education',
-            u'mailing_address',
-            u'goals',
-            u'honor_code'
+            u"email",
+            u"username",
+            u"password",
+            u"confirm_password",
+            u"first_name",
+            u"last_name",
+            u"opt_in",
+            u"city",
+            u"state",
+            u"country",
+            u"gender",
+            u"year_of_birth",
+            u"level_of_education",
+            u"mailing_address",
+            u"goals",
+            u"honor_code"        
         ])
 
     def test_extension_form_fields(self):

--- a/lms/djangoapps/philu_overrides/user_api/tests/test_views.py
+++ b/lms/djangoapps/philu_overrides/user_api/tests/test_views.py
@@ -4,6 +4,8 @@ import datetime
 import json
 from unittest import SkipTest, skipUnless
 
+from pytz import UTC
+
 import ddt
 import factory
 import httpretty
@@ -15,23 +17,22 @@ from django.db.models.signals import post_save
 from django.test.client import RequestFactory
 from django.test.testcases import TransactionTestCase
 from django.test.utils import override_settings
-from pytz import UTC
-from social.apps.django_app.default.models import UserSocialAuth
-from third_party_auth.tests.testutil import ThirdPartyAuthTestMixin
-from third_party_auth.tests.utils import (ThirdPartyOAuthTestMixin, ThirdPartyOAuthTestMixinFacebook,
-                                          ThirdPartyOAuthTestMixinGoogle)
-
 from lms.djangoapps.onboarding.tests.factories import UserFactory
 from lms.djangoapps.philu_overrides.user_api.views import RegistrationViewCustom
-from openedx.core.djangoapps.user_api.accounts import (EMAIL_MAX_LENGTH, EMAIL_MIN_LENGTH,
-                                                       PASSWORD_MAX_LENGTH, PASSWORD_MIN_LENGTH, USERNAME_MAX_LENGTH,
+from openedx.core.djangoapps.user_api.accounts import (EMAIL_MAX_LENGTH, EMAIL_MIN_LENGTH, PASSWORD_MAX_LENGTH,
+                                                       PASSWORD_MIN_LENGTH, USERNAME_MAX_LENGTH,
                                                        USERNAME_MIN_LENGTH)
 from openedx.core.djangoapps.user_api.accounts.api import get_account_settings
 from openedx.core.djangoapps.user_api.tests.test_constants import SORTED_COUNTRIES
 from openedx.core.djangoapps.user_api.tests.test_helpers import TestCaseForm
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase
 from openedx.core.lib.api.test_utils import ApiTestCase
-from .utils import simulate_running_pipeline, mocked_registration_view_post_method
+from social.apps.django_app.default.models import UserSocialAuth
+from third_party_auth.tests.testutil import ThirdPartyAuthTestMixin
+from third_party_auth.tests.utils import (ThirdPartyOAuthTestMixin, ThirdPartyOAuthTestMixinFacebook,
+                                          ThirdPartyOAuthTestMixinGoogle)
+
+from .utils import mocked_registration_view_post_method, simulate_running_pipeline
 
 
 @ddt.ddt
@@ -602,10 +603,10 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, ApiTestCase):
     def test_register_form_year_of_birth(self):
         this_year = datetime.datetime.now(UTC).year
         year_options = (
-                [{"value": "", "name": "--", "default": True}] + [
-            {"value": unicode(year), "name": unicode(year)}
-            for year in range(this_year, this_year - 120, -1)
-        ]
+            [{"value": "", "name": "--", "default": True}] + [
+                {"value": unicode(year), "name": unicode(year)}
+                for year in range(this_year, this_year - 120, -1)
+            ]
         )
         self._assert_reg_field(
             {"year_of_birth": "optional"},
@@ -666,11 +667,11 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, ApiTestCase):
 
     def test_registration_form_country(self):
         country_options = (
-                [{"name": "--", "value": "", "default": True}] +
-                [
-                    {"value": country_code, "name": unicode(country_name)}
-                    for country_code, country_name in SORTED_COUNTRIES
-                ]
+            [{"name": "--", "value": "", "default": True}] +
+            [
+                {"value": country_code, "name": unicode(country_name)}
+                for country_code, country_name in SORTED_COUNTRIES
+            ]
         )
         self._assert_reg_field(
             {"country": "required"},
@@ -701,7 +702,7 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, ApiTestCase):
                 "type": "checkbox",
                 "required": True,
                 "errorMessages": {
-                    "required": "Please accept our Terms and Conditions by checking the Terms and Conditions" \
+                    "required": "Please accept our Terms and Conditions by checking the Terms and Conditions"
                                 " checkbox before creating an account."
                 }
             }
@@ -720,7 +721,7 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, ApiTestCase):
                 "type": "checkbox",
                 "required": True,
                 "errorMessages": {
-                    "required": "Please accept our Terms and Conditions by checking the Terms and Conditions" \
+                    "required": "Please accept our Terms and Conditions by checking the Terms and Conditions"
                                 " checkbox before creating an account."
                 }
             }
@@ -745,7 +746,7 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, ApiTestCase):
                 "type": "checkbox",
                 "required": True,
                 "errorMessages": {
-                    "required": "Please accept our Terms and Conditions by checking the Terms and Conditions" \
+                    "required": "Please accept our Terms and Conditions by checking the Terms and Conditions"
                                 " checkbox before creating an account."
                 }
             }
@@ -787,7 +788,7 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, ApiTestCase):
                 "type": "checkbox",
                 "required": True,
                 "errorMessages": {
-                    "required": "Please accept our Terms and Conditions by checking the Terms and Conditions" \
+                    "required": "Please accept our Terms and Conditions by checking the Terms and Conditions"
                                 " checkbox before creating an account."
                 }
             }

--- a/lms/djangoapps/philu_overrides/user_api/tests/utils.py
+++ b/lms/djangoapps/philu_overrides/user_api/tests/utils.py
@@ -3,12 +3,11 @@ from contextlib import contextmanager
 import mock
 from django.core.exceptions import NON_FIELD_ERRORS
 from django.core.validators import ValidationError
-from student.cookies import set_logged_in_cookies
-from util.json_request import JsonResponse
-
 from lms.djangoapps.onboarding.models import RegistrationType
 from lms.djangoapps.philu_overrides.helpers import save_user_partner_network_consent
 from lms.djangoapps.philu_overrides.user_api.views import create_account_with_params_custom
+from student.cookies import set_logged_in_cookies
+from util.json_request import JsonResponse
 
 
 @contextmanager

--- a/lms/djangoapps/philu_overrides/user_api/tests/utils.py
+++ b/lms/djangoapps/philu_overrides/user_api/tests/utils.py
@@ -1,0 +1,8 @@
+from common.djangoapps.third_party_auth.tests.utils import ThirdPartyOAuthTestMixinFacebook
+
+class ThirdPartyOAuthTestMixinGoogle(object):
+    """Tests oauth with the Google backend"""
+    BACKEND = "google-oauth2"
+    USER_URL = "https://www.googleapis.com/oauth2/v3/userinfo"
+    # In google-oauth2 responses, the "email" field is used as the user's identifier
+    UID_FIELD = "email"

--- a/lms/djangoapps/philu_overrides/user_api/tests/utils.py
+++ b/lms/djangoapps/philu_overrides/user_api/tests/utils.py
@@ -1,8 +1,85 @@
-from common.djangoapps.third_party_auth.tests.utils import ThirdPartyOAuthTestMixinFacebook
+import mock
 
-class ThirdPartyOAuthTestMixinGoogle(object):
-    """Tests oauth with the Google backend"""
-    BACKEND = "google-oauth2"
-    USER_URL = "https://www.googleapis.com/oauth2/v3/userinfo"
-    # In google-oauth2 responses, the "email" field is used as the user's identifier
-    UID_FIELD = "email"
+from contextlib import contextmanager
+
+
+@contextmanager
+def simulate_running_pipeline(pipeline_target, backend, email=None, fullname=None, username=None):
+    """Simulate that a pipeline is currently running.
+
+    You can use this context manager to test packages that rely on third party auth.
+
+    This uses `mock.patch` to override some calls in `third_party_auth.pipeline`,
+    so you will need to provide the "target" module *as it is imported*
+    in the software under test.  For example, if `foo/bar.py` does this:
+
+    >>> from third_party_auth import pipeline
+
+    then you will need to do something like this:
+
+    >>> with simulate_running_pipeline("foo.bar.pipeline", "google-oauth2"):
+    >>>    bar.do_something_with_the_pipeline()
+
+    If, on the other hand, `foo/bar.py` had done this:
+
+    >>> import third_party_auth
+
+    then you would use the target "foo.bar.third_party_auth.pipeline" instead.
+
+    Arguments:
+
+        pipeline_target (string): The path to `third_party_auth.pipeline` as it is imported
+            in the software under test.
+
+        backend (string): The name of the backend currently running, for example "google-oauth2".
+            Note that this is NOT the same as the name of the *provider*.  See the Python
+            social auth documentation for the names of the backends.
+
+    Keyword Arguments:
+        email (string): If provided, simulate that the current provider has
+            included the user's email address (useful for filling in the registration form).
+
+        fullname (string): If provided, simulate that the current provider has
+            included the user's full name (useful for filling in the registration form).
+
+        username (string): If provided, simulate that the pipeline has provided
+            this suggested username.  This is something that the `third_party_auth`
+            app generates itself and should be available by the time the user
+            is authenticating with a third-party provider.
+
+    Returns:
+        None
+
+    """
+    pipeline_data = {
+        "backend": backend,
+        "kwargs": {
+            "details": {},
+            'response': {
+                'access_token': 'dummy access token'
+            }
+        }
+    }
+
+    if email is not None:
+        pipeline_data["kwargs"]["details"]["email"] = email
+    if fullname is not None:
+        pipeline_data["kwargs"]["details"]["fullname"] = fullname
+    if username is not None:
+        pipeline_data["kwargs"]["username"] = username
+
+    pipeline_get = mock.patch("{pipeline}.get".format(pipeline=pipeline_target), spec=True)
+    pipeline_running = mock.patch("{pipeline}.running".format(pipeline=pipeline_target), spec=True)
+
+    mock_get = pipeline_get.start()
+    mock_running = pipeline_running.start()
+
+    mock_get.return_value = pipeline_data
+    mock_running.return_value = True
+
+    try:
+        yield
+
+    finally:
+        pipeline_get.stop()
+        pipeline_running.stop()

--- a/lms/djangoapps/philu_overrides/user_api/tests/utils.py
+++ b/lms/djangoapps/philu_overrides/user_api/tests/utils.py
@@ -1,13 +1,14 @@
-import mock
-
 from contextlib import contextmanager
-from lms.djangoapps.onboarding.models import RegistrationType
-from student.cookies import set_logged_in_cookies
-from lms.djangoapps.philu_overrides.user_api.views import create_account_with_params_custom
-from lms.djangoapps.philu_overrides.helpers import save_user_partner_network_consent
-from util.json_request import JsonResponse
-from django.core.validators import ValidationError
+
+import mock
 from django.core.exceptions import NON_FIELD_ERRORS
+from django.core.validators import ValidationError
+from student.cookies import set_logged_in_cookies
+from util.json_request import JsonResponse
+
+from lms.djangoapps.onboarding.models import RegistrationType
+from lms.djangoapps.philu_overrides.helpers import save_user_partner_network_consent
+from lms.djangoapps.philu_overrides.user_api.views import create_account_with_params_custom
 
 
 @contextmanager


### PR DESCRIPTION
coverage for lms/djangoapps/philu_overrides/user_api/views.py is 74%

To execute the tests related to third_party, first set "ENABLE_THIRD_PARTY_AUTH" option true.