### PR TITLE
Change imports of student app views according to structure change

### DIFF
--- a/common/djangoapps/course_modes/views.py
+++ b/common/djangoapps/course_modes/views.py
@@ -25,7 +25,7 @@ from six import text_type
 from course_modes.models import CourseMode
 from courseware.access import has_access
 from edxmako.shortcuts import render_to_response
-from common.djangoapps.student.views.management import get_course_related_keys
+from common.djangoapps.student.views import get_course_related_keys
 from lms.djangoapps.commerce.utils import EcommerceService
 from lms.djangoapps.experiments.utils import get_experiment_user_metadata_context
 from openedx.core.djangoapps.catalog.utils import get_currency_data

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -61,7 +61,7 @@ from courseware.user_state_client import DjangoXBlockUserStateClient
 from edxmako.shortcuts import marketing_link, render_to_response, render_to_string
 from enrollment.api import add_enrollment
 from ipware.ip import get_ip
-from common.djangoapps.student.views.management import get_course_related_keys
+from common.djangoapps.student.views import get_course_related_keys
 from lms.djangoapps.ccx.custom_exception import CCXLocatorValidationException
 from lms.djangoapps.certificates import api as certs_api
 from lms.djangoapps.certificates.models import CertificateStatuses

--- a/lms/djangoapps/philu_overrides/helpers.py
+++ b/lms/djangoapps/philu_overrides/helpers.py
@@ -143,7 +143,7 @@ def get_user_current_enrolled_class(request, course):
     from datetime import datetime
     from django.core.urlresolvers import reverse
     from opaque_keys.edx.locations import SlashSeparatedCourseKey
-    from common.djangoapps.student.views.management import get_course_related_keys
+    from common.djangoapps.student.views import get_course_related_keys
     from student.models import CourseEnrollment
     from course_action_state.models import CourseRerunState
 

--- a/lms/djangoapps/philu_overrides/views.py
+++ b/lms/djangoapps/philu_overrides/views.py
@@ -31,7 +31,7 @@ from third_party_auth.decorators import xframe_allow_whitelisted
 from util.cache import cache_if_anonymous
 from util.enterprise_helpers import set_enterprise_branding_filter_param
 from xmodule.modulestore.django import modulestore
-from common.djangoapps.student.views.management import get_course_related_keys
+from common.djangoapps.student.views import get_course_related_keys
 from lms.djangoapps.courseware.access import has_access, _can_enroll_courselike
 from lms.djangoapps.courseware.courses import get_courses, sort_by_start_date, get_course_by_id, sort_by_announcement
 from lms.djangoapps.courseware.views.views import get_last_accessed_courseware

--- a/openedx/core/djangoapps/timed_notification/core.py
+++ b/openedx/core/djangoapps/timed_notification/core.py
@@ -1,6 +1,6 @@
 import logging
 
-from common.djangoapps.student.views.management import get_course_related_keys
+from common.djangoapps.student.views import get_course_related_keys
 from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.courseware.views.views import get_last_accessed_courseware
 from opaque_keys.edx.locations import SlashSeparatedCourseKey

--- a/openedx/features/student_certificates/views.py
+++ b/openedx/features/student_certificates/views.py
@@ -14,7 +14,7 @@ from courseware.courses import get_course
 from certificates.models import (
     GeneratedCertificate,
     CertificateStatuses)
-from common.djangoapps.student.views.dashboard import get_course_enrollments
+from common.djangoapps.student.views import get_course_enrollments
 
 from helpers import get_certificate_image_url, get_philu_certificate_social_context
 


### PR DESCRIPTION
**Description**
Ironwood Combines all of the broken out student views in `__init__.py` of `student.views` . So I created this PR to change relevant imports.