### PR TITLE
[LP-1503] Backend Implementation of setting course dates based on course start date

### DIFF
--- a/openedx/features/course_card/helpers.py
+++ b/openedx/features/course_card/helpers.py
@@ -96,17 +96,3 @@ def get_course_cards_list():
     course_card_ids = [cc.course_id for cc in cards_query_set]
     courses_list = CourseOverview.objects.select_related('image_set').filter(id__in=course_card_ids)
     return courses_list
-
-
-def initialize_course_settings(source_course_key, destination_course_key):
-    """
-    When ever a new course is created
-    1: We add a default entry for the given course in the CustomSettings Model
-    2: We add a an honor mode for the given course so students can view certificates on their dashboard and progress page
-    """
-
-    if source_course_key:
-        _settings = CustomSettings.objects.filter(id=source_course_key).first()
-        tags = _settings.tags
-        CustomSettings.objects.filter(id=destination_course_key).update(tags=tags)
-

--- a/openedx/features/course_card/tests/test_helpers.py
+++ b/openedx/features/course_card/tests/test_helpers.py
@@ -106,21 +106,3 @@ class CourseCardHelperBaseClass(CourseCardBaseClass):
         # For Staff User
         # Desired output is a list of all course overview objects
         self.assertEqual({c.id for c in get_course_cards_list()}, {course.id for course in self.courses})
-
-    def test_initialize_course_settings(self):
-        parent_course_id = self.rerun_parent_course.id
-        re_run_course_id = self.re_run_course.id
-
-        custom_tags = '{"test_key": "test_value"}'
-        custom_settings = CustomSettings.objects.get(id=parent_course_id)
-
-        custom_settings.tags = custom_tags
-        custom_settings.save()
-
-        initialize_course_settings(parent_course_id, re_run_course_id)
-
-        # Desired output is that the tags have been set in the rerun course custom settings as per the parent course
-        self.assertEqual(CustomSettings.objects.get(id=re_run_course_id).tags, custom_tags)
-
-        # If parent course id is not provided or is none method returns none
-        self.assertIsNone(initialize_course_settings(None, re_run_course_id))


### PR DESCRIPTION
[LP-1503](https://philanthropyu.atlassian.net/browse/LP-1503)
Added method set_rerun_schedule_dates to set schedule dates,
Added method set_advanced_settings_due_date to set due_date,
moved method initialze_course_settings from course_card to features/cms/helpers
added flag to set custom_settings course open date in initialize_course_settings_method
fixed case where date had no timezone in delta computation