### PR TITLE
LP-1099 Change email in NodeBB, Mailchimp when admin updates it

### DIFF
--- a/common/djangoapps/mailchimp_pipeline/signals/handlers.py
+++ b/common/djangoapps/mailchimp_pipeline/signals/handlers.py
@@ -142,7 +142,6 @@ def send_user_info_to_mailchimp(sender, user, created, kwargs):
 
 
 def update_user_email_in_mailchimp(old_email, new_email):
-    """ Update user email in mailchimp member list """
 
     user_json = {
         "email_address": new_email,

--- a/common/djangoapps/mailchimp_pipeline/signals/handlers.py
+++ b/common/djangoapps/mailchimp_pipeline/signals/handlers.py
@@ -141,6 +141,16 @@ def send_user_info_to_mailchimp(sender, user, created, kwargs):
     update_mailchimp(user.email, user_json)
 
 
+def update_user_email_in_mailchimp(old_email, new_email):
+    """ Update user email in mailchimp member list """
+
+    user_json = {
+        "email_address": new_email,
+    }
+
+    update_mailchimp(old_email, user_json)
+
+
 @task(routing_key=settings.HIGH_PRIORITY_QUEUE)
 def task_send_account_activation_email(data):
 

--- a/common/lib/mandrill_client/client.py
+++ b/common/lib/mandrill_client/client.py
@@ -30,6 +30,7 @@ class MandrillClient(object):
     ON_DEMAND_WEEKLY_MODULE_COMPLETE_TEMPLATE = 'module-completion-weekly-email'
     ON_DEMAND_WEEKLY_MODULE_SKIP_TEMPLATE = 'on-demand-module-skip'
     ON_DEMAND_REMINDER_EMAIL_TEMPLATE = 'on-demand-reminder-email'
+    CHANGE_USER_EMAIL_ALERT = 'change-user-email-alert'
 
     def __init__(self):
         self.mandrill_client = mandrill.Mandrill(settings.MANDRILL_API_KEY)

--- a/lms/djangoapps/onboarding/handlers.py
+++ b/lms/djangoapps/onboarding/handlers.py
@@ -127,7 +127,21 @@ def delete_all_user_data(sender, instance, **kwargs):
 @receiver(USER_FIELD_CHANGED)
 def propagate_email_change(sender, user=None, table=None, setting=None, old_value=None,
                            new_value=None, **kwargs):
-    """This method listens for change in user model. Once it detects change in email, it propagate
-    change, where required i.e. NodeBB, Mailchimp etc"""
-    if setting == "email" and new_value and new_value != old_value:
+    """
+    This method listens for change in user model. Once it detects change in email, it propagate
+    change, where required i.e. NodeBB, Mailchimp etc
+    :param sender: Not used
+    :param user: The user object for the user being changed
+    :param table: The name of the table being updated
+    :param setting: The name of the field (column) being updated
+    :param old_value: Prior value
+    :param new_value: New value
+    :param kwargs: Not used
+    :return: None
+    """
+    # ignore tables except user and fields except email
+    if table != "auth_user" or setting != "email":
+        return
+
+    if new_value and new_value != old_value:
         update_user_email(user, old_value, new_value)

--- a/lms/djangoapps/onboarding/handlers.py
+++ b/lms/djangoapps/onboarding/handlers.py
@@ -12,9 +12,14 @@ from lms.djangoapps.onboarding.models import Organization, OrganizationMetric,\
         OrganizationMetricUpdatePrompt, MetricUpdatePromptRecord
 from lms.djangoapps.oef.models import OrganizationOefUpdatePrompt
 from lms.djangoapps.onboarding.constants import  REMIND_ME_LATER_KEY, TAKE_ME_THERE_KEY, NOT_INTERESTED_KEY
-from lms.djangoapps.onboarding.helpers import its_been_year, its_been_year_month, \
-    its_been_year_three_month, its_been_year_six_month
-
+from util.model_utils import USER_FIELD_CHANGED
+from lms.djangoapps.onboarding.helpers import (
+    its_been_year,
+    its_been_year_month,
+    its_been_year_three_month,
+    its_been_year_six_month,
+    update_user_email
+)
 
 @receiver(post_save, sender=User)
 def update_user_profile(sender, instance, update_fields, **kwargs):
@@ -117,3 +122,12 @@ def delete_all_user_data(sender, instance, **kwargs):
         'UPDATE onboarding_organization SET alternate_admin_email=NULL WHERE alternate_admin_email="{}"'.format(instance.email))
     cursor.execute(
         'DELETE FROM onboarding_historicalorganization WHERE unclaimed_org_admin_email="{}" OR alternate_admin_email="{}"'.format(instance.email, instance.email))
+
+
+@receiver(USER_FIELD_CHANGED)
+def propagate_email_change(sender, user=None, table=None, setting=None, old_value=None,
+                           new_value=None, **kwargs):
+    """This method listens for change in user model. Once it detects change in email, it propagate
+    change, where required i.e. NodeBB, Mailchimp etc"""
+    if setting == "email" and new_value and new_value != old_value:
+        update_user_email(user, old_value, new_value)

--- a/lms/djangoapps/onboarding/helpers.py
+++ b/lms/djangoapps/onboarding/helpers.py
@@ -10,8 +10,14 @@ from django.conf import settings
 from django.core import serializers
 
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
-from lms.djangoapps.onboarding.models import Organization, OrganizationMetricUpdatePrompt, PartnerNetwork
 from lms.djangoapps.oef.models import OrganizationOefUpdatePrompt
+from common.lib.mandrill_client.client import MandrillClient
+from openedx.features.data_extract.models import CourseDataExtraction
+from common.djangoapps.mailchimp_pipeline.signals.handlers import update_user_email_in_mailchimp
+from common.djangoapps.nodebb.tasks import task_update_user_profile_on_nodebb
+from lms.djangoapps.onboarding.models import (
+    Organization, OrganizationMetricUpdatePrompt, PartnerNetwork, OrganizationAdminHashKeys
+)
 
 utc = pytz.UTC
 log = getLogger(__name__)
@@ -8085,3 +8091,46 @@ def get_user_anonymous_id(user, course_id):
         raise AnonymousUserId.DoesNotExist('Anonymous Id doesn\'t exists for %s' % user)
     except AnonymousUserId.MultipleObjectsReturned:
         raise AnonymousUserId.MultipleObjectsReturned('Multiple Anonymous Ids for %s' % user)
+
+
+def update_user_email(user, old_email, new_email):
+    """
+    This method updates email in NodeBB, Mailchimp, platform database. In the end emails are send
+    to user's new and old email to let him know the status.
+    :param user: user whose email is changed
+    :param old_email: user's previous email
+    :param new_email: user's new email
+    :return: None
+    """
+
+    from student.models import CourseEnrollmentAllowed, ManualEnrollmentAudit, UserProfile
+
+    # update email in mailchimp
+    update_user_email_in_mailchimp(old_email, new_email)
+
+    # update email in NodeBB
+    data_to_sync = {
+        "email": new_email
+    }
+    task_update_user_profile_on_nodebb.delay(
+        username=user.username, profile_data=data_to_sync)
+
+    # update email manually in platform database, where required
+    ManualEnrollmentAudit.objects.filter(enrolled_email=old_email).update(enrolled_email=new_email)
+    CourseEnrollmentAllowed.objects.filter(email=old_email).update(email=new_email)
+    OrganizationAdminHashKeys.objects.filter(suggested_admin_email=old_email).update(
+        suggested_admin_email=new_email)
+    CourseDataExtraction.objects.filter(emails=old_email).update(emails=new_email)
+    Organization.objects.filter(unclaimed_org_admin_email=old_email).update(
+        unclaimed_org_admin_email=new_email)
+    Organization.objects.filter(alternate_admin_email=old_email).update(
+        alternate_admin_email=new_email)
+
+    # send email to new and old account
+    context = {
+        'old_email': old_email,
+        'new_email': new_email,
+        'platform_name': configuration_helpers.get_value("PLATFORM_NAME", settings.PLATFORM_NAME)
+    }
+    MandrillClient().send_mail(MandrillClient.CHANGE_USER_EMAIL_ALERT, old_email, context)
+    MandrillClient().send_mail(MandrillClient.CHANGE_USER_EMAIL_ALERT, new_email, context)

--- a/lms/djangoapps/onboarding/helpers.py
+++ b/lms/djangoapps/onboarding/helpers.py
@@ -9,15 +9,15 @@ from difflib import SequenceMatcher
 from django.conf import settings
 from django.core import serializers
 
-from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
-from lms.djangoapps.oef.models import OrganizationOefUpdatePrompt
 from common.lib.mandrill_client.client import MandrillClient
-from openedx.features.data_extract.models import CourseDataExtraction
 from common.djangoapps.mailchimp_pipeline.signals.handlers import update_user_email_in_mailchimp
 from common.djangoapps.nodebb.tasks import task_update_user_profile_on_nodebb
+from lms.djangoapps.oef.models import OrganizationOefUpdatePrompt
 from lms.djangoapps.onboarding.models import (
     Organization, OrganizationMetricUpdatePrompt, PartnerNetwork, OrganizationAdminHashKeys
 )
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+from openedx.features.data_extract.models import CourseDataExtraction
 
 utc = pytz.UTC
 log = getLogger(__name__)


### PR DESCRIPTION
## [LP-1099](https://philanthropyu.atlassian.net/browse/LP-1099)

- Allow registered learners to change their email address - Part 1: Backend implementation
- This PR allow admin to change email in NodeBB, Mailchimp and sends email to old and new emails

Note: This PR has a corresponding [PR-517](https://github.com/philanthropy-u/nodebb-theme-philu-community/pull/517) in NodeBB theme