### PR TITLE
Remove hide password field code in third party auth registration form

### DIFF
--- a/openedx/core/djangoapps/user_api/api.py
+++ b/openedx/core/djangoapps/user_api/api.py
@@ -989,16 +989,6 @@ class RegistrationFormFactory(object):
                                     instructions="",
                                 )
 
-                    # Hide the password field
-                    form_desc.override_field_properties(
-                        "password",
-                        default="",
-                        field_type="hidden",
-                        required=False,
-                        label="",
-                        instructions="",
-                        restrictions={}
-                    )
                     # used to identify that request is running third party social auth
                     form_desc.add_field(
                         "social_auth_provider",


### PR DESCRIPTION
Philu requires password even in case of registration using third party auth providers