### PR TITLE
Add unit tests for badge, userbadge models and respective views

### DIFF
--- a/lms/djangoapps/philu_api/tests/test_views.py
+++ b/lms/djangoapps/philu_api/tests/test_views.py
@@ -1,0 +1,64 @@
+import json
+from mock import patch
+
+from django.conf import settings
+from django.core.urlresolvers import reverse
+from django.test import RequestFactory, TestCase
+
+from lms.djangoapps.philu_api.views import assign_user_badge
+
+
+class BadgeAssignViewTest(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.assign_path = reverse('assign_user_badge')
+
+    @patch('lms.djangoapps.philu_api.views.UserBadge.assign_badge')
+    def test_assign_user_badge_wrong_token(self, mock_userbadge_assign_badge):
+        dict_data = {
+            "user_id": "16",
+            "badge_id": "1",
+            "community_id": "-1",
+            "token": "wrong_token"
+        }
+        request = self.factory.post(self.assign_path, data=json.dumps(dict_data), content_type='application/json')
+
+        response = assign_user_badge(request)
+
+        assert not mock_userbadge_assign_badge.called
+
+        self.assertEqual(response.status_code, 403)
+
+    @patch('lms.djangoapps.philu_api.views.UserBadge.assign_badge')
+    def test_assign_user_badge(self, mock_userbadge_assign_badge):
+        dict_data = {
+            "user_id": "16",
+            "badge_id": "1",
+            "community_id": "-1",
+            "token": settings.NODEBB_MASTER_TOKEN
+        }
+        request = self.factory.post(self.assign_path, data=json.dumps(dict_data), content_type='application/json')
+
+        response = assign_user_badge(request)
+
+        assert mock_userbadge_assign_badge.called
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, '{"success": true}')
+
+    @patch('lms.djangoapps.philu_api.views.UserBadge.assign_badge')
+    def test_assign_user_badge_exception(self, mock_userbadge_assign_badge):
+        dict_data = {
+            "user_id": "16",
+            "badge_id": "1",
+            "community_id": "-1",
+            "token": settings.NODEBB_MASTER_TOKEN
+        }
+        request = self.factory.post(self.assign_path, data=json.dumps(dict_data), content_type='application/json')
+
+        mock_userbadge_assign_badge.side_effect = Exception()
+        response = assign_user_badge(request)
+
+        assert mock_userbadge_assign_badge.called
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.content, '{"message": "", "success": false}')

--- a/lms/djangoapps/philu_api/tests/test_views.py
+++ b/lms/djangoapps/philu_api/tests/test_views.py
@@ -8,6 +8,15 @@ from django.test import RequestFactory, TestCase
 from lms.djangoapps.philu_api.views import assign_user_badge
 
 
+def assign_badge_request_body(uid, bid, cid, token):
+    return {
+        "user_id": uid,
+        "badge_id": bid,
+        "community_id": cid,
+        "token": token
+    }
+
+
 class BadgeAssignViewTest(TestCase):
     def setUp(self):
         self.factory = RequestFactory()
@@ -15,48 +24,37 @@ class BadgeAssignViewTest(TestCase):
 
     @patch('lms.djangoapps.philu_api.views.UserBadge.assign_badge')
     def test_assign_user_badge_wrong_token(self, mock_userbadge_assign_badge):
-        dict_data = {
-            "user_id": "16",
-            "badge_id": "1",
-            "community_id": "-1",
-            "token": "wrong_token"
-        }
-        request = self.factory.post(self.assign_path, data=json.dumps(dict_data), content_type='application/json')
+        request_body = assign_badge_request_body("16", "1", "-1", "wrong_token")
 
+        request = self.factory.post(self.assign_path,
+                                    data=json.dumps(request_body),
+                                    content_type='application/json')
         response = assign_user_badge(request)
 
         assert not mock_userbadge_assign_badge.called
-
         self.assertEqual(response.status_code, 403)
 
     @patch('lms.djangoapps.philu_api.views.UserBadge.assign_badge')
     def test_assign_user_badge(self, mock_userbadge_assign_badge):
-        dict_data = {
-            "user_id": "16",
-            "badge_id": "1",
-            "community_id": "-1",
-            "token": settings.NODEBB_MASTER_TOKEN
-        }
-        request = self.factory.post(self.assign_path, data=json.dumps(dict_data), content_type='application/json')
+        request_body = assign_badge_request_body("16", "1", "-1", settings.NODEBB_MASTER_TOKEN)
 
+        request = self.factory.post(self.assign_path,
+                                    data=json.dumps(request_body),
+                                    content_type='application/json')
         response = assign_user_badge(request)
 
         assert mock_userbadge_assign_badge.called
-
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content, '{"success": true}')
 
     @patch('lms.djangoapps.philu_api.views.UserBadge.assign_badge')
     def test_assign_user_badge_exception(self, mock_userbadge_assign_badge):
-        dict_data = {
-            "user_id": "16",
-            "badge_id": "1",
-            "community_id": "-1",
-            "token": settings.NODEBB_MASTER_TOKEN
-        }
-        request = self.factory.post(self.assign_path, data=json.dumps(dict_data), content_type='application/json')
-
+        request_body = assign_badge_request_body("16", "1", "-1", settings.NODEBB_MASTER_TOKEN)
         mock_userbadge_assign_badge.side_effect = Exception()
+
+        request = self.factory.post(self.assign_path,
+                                    data=json.dumps(request_body),
+                                    content_type='application/json')
         response = assign_user_badge(request)
 
         assert mock_userbadge_assign_badge.called

--- a/openedx/features/badging/tests/factories.py
+++ b/openedx/features/badging/tests/factories.py
@@ -1,0 +1,19 @@
+from factory.django import DjangoModelFactory
+
+from openedx.features.badging.models import Badge, UserBadge
+
+
+class BadgeFactory(DjangoModelFactory):
+    class Meta(object):
+        model = Badge
+
+    description = "This is a sample badge"
+    image = "path/to/image"
+
+
+class UserBadgeFactory(DjangoModelFactory):
+    class Meta(object):
+        model = UserBadge
+
+    course_id = ""
+    community_id = -1

--- a/openedx/features/badging/tests/test_model_badge.py
+++ b/openedx/features/badging/tests/test_model_badge.py
@@ -12,6 +12,8 @@ from common.djangoapps.nodebb.constants import (
 from openedx.features.badging.constants import CONVERSATIONALIST, TEAM_PLAYER
 from openedx.features.badging.models import Badge, UserBadge
 
+from openedx.features.badging.tests.factories import BadgeFactory, UserBadgeFactory
+
 
 def get_expected_badge_data(badge):
     return {
@@ -56,12 +58,8 @@ class BadgeModelTestCases(TestCase):
         Get unearned badges dictionary after saving badges
         when none of the badges has been earned
         """
-        badge_1 = Badge.objects.create(name="badge_1", description="This is a sample badge",
-                                       threshold=30, type=TEAM_PLAYER[TEAM_PLAYER_ENTRY_INDEX],
-                                       image="path/to/image")
-        badge_2 = Badge.objects.create(name="badge_2", description="This is a sample badge",
-                                       threshold=70, type=TEAM_PLAYER[TEAM_PLAYER_ENTRY_INDEX],
-                                       image="path/to/image")
+        badge_1 = BadgeFactory(name="badge_1", threshold=30, type=TEAM_PLAYER[TEAM_PLAYER_ENTRY_INDEX])
+        badge_2 = BadgeFactory(name="badge_2", threshold=70, type=TEAM_PLAYER[TEAM_PLAYER_ENTRY_INDEX])
         expected_result = {}
         expected_result["1"] = get_expected_badge_data(badge_1)
         expected_result["2"] = get_expected_badge_data(badge_2)
@@ -82,18 +80,10 @@ class BadgeModelTestCases(TestCase):
         Get unearned badges dictionary after saving badges
         when user has already earned one of the badges
         """
-        badge_1 = Badge.objects.create(name="badge_1", description="This is a sample badge",
-                                       threshold=30, type=TEAM_PLAYER[TEAM_PLAYER_ENTRY_INDEX],
-                                       image="path/to/image")
-        badge_2 = Badge.objects.create(name="badge_2", description="This is a sample badge",
-                                       threshold=70, type=TEAM_PLAYER[TEAM_PLAYER_ENTRY_INDEX],
-                                       image="path/to/image")
-        UserBadge.objects.create(
-            user_id=self.user.id,
-            badge_id=badge_1.id,
-            course_id="",
-            community_id=-1
-        )
+        badge_1 = BadgeFactory(name="badge_1", threshold=30, type=TEAM_PLAYER[TEAM_PLAYER_ENTRY_INDEX])
+        badge_2 = BadgeFactory(name="badge_2", threshold=70, type=TEAM_PLAYER[TEAM_PLAYER_ENTRY_INDEX])
+
+        UserBadgeFactory(user_id=self.user.id, badge_id=badge_1.id)
 
         expected_result = {}
         expected_result["1"] = get_expected_badge_data(badge_2)
@@ -113,25 +103,11 @@ class BadgeModelTestCases(TestCase):
         Get unearned badges dictionary after saving badges
         when user has already earned all of the badges
         """
-        badge_1 = Badge.objects.create(name="badge_1", description="This is a sample badge",
-                                       threshold=30, type=TEAM_PLAYER[TEAM_PLAYER_ENTRY_INDEX],
-                                       image="path/to/image")
-        badge_2 = Badge.objects.create(name="badge_2", description="This is a sample badge",
-                                       threshold=70, type=TEAM_PLAYER[TEAM_PLAYER_ENTRY_INDEX],
-                                       image="path/to/image")
-        UserBadge.objects.create(
-            user_id=self.user.id,
-            badge_id=badge_1.id,
-            course_id="",
-            community_id=-1
-        )
+        badge_1 = BadgeFactory(name="badge_1", threshold=30, type=TEAM_PLAYER[TEAM_PLAYER_ENTRY_INDEX])
+        badge_2 = BadgeFactory(name="badge_2", threshold=70, type=TEAM_PLAYER[TEAM_PLAYER_ENTRY_INDEX])
 
-        UserBadge.objects.create(
-            user_id=self.user.id,
-            badge_id=badge_2.id,
-            course_id="",
-            community_id=-1
-        )
+        UserBadgeFactory(user_id=self.user.id, badge_id=badge_1.id)
+        UserBadgeFactory(user_id=self.user.id, badge_id=badge_2.id)
 
         expected_result = {}
         actual_result = Badge.get_unearned_badges(user_id=self.user.id,

--- a/openedx/features/badging/tests/test_model_badge.py
+++ b/openedx/features/badging/tests/test_model_badge.py
@@ -1,0 +1,244 @@
+from django.contrib.auth.models import User
+from django.db import IntegrityError, transaction
+from django.test import TestCase
+from django.utils import timezone
+
+from common.djangoapps.nodebb.constants import (
+    COMMUNITY_ID_SPLIT_INDEX,
+    TEAM_PLAYER_ENTRY_INDEX,
+    CONVERSATIONALIST_ENTRY_INDEX
+)
+
+from openedx.features.badging.constants import CONVERSATIONALIST, TEAM_PLAYER
+from openedx.features.badging.models import Badge, UserBadge
+
+
+class BadgeModelTestCases(TestCase):
+    def test_name_blank_raises_IntegrityError(self):
+        """
+        Trying to save a Badge object with no name raises
+        an IntegrityError exception.
+        """
+        badge = Badge(name=None,
+                      description="This is a sample badge",
+                      threshold=30,
+                      type="conversationalist",
+                      image="path/too/image",
+                      date_created=timezone.now())
+
+        with self.assertRaises(IntegrityError):
+            with transaction.atomic():
+                badge.save()
+        badge.delete
+
+    def test_description_blank_no_exception(self):
+        """
+        Trying to save a Badge object with no description
+        does not raise any exception.
+        """
+        badge_name = "Sample Badge"
+        badge = Badge(name=badge_name,
+                      description=None,
+                      threshold=30,
+                      type="conversationalist",
+                      image="path/too/image",
+                      date_created=timezone.now())
+        badge.save()
+        saved_badge = Badge.objects.get(name=badge_name)
+        self.assertEquals(badge, saved_badge)
+
+    def test_threshold_blank_raises_IntegrityError(self):
+        """
+        Trying to save a Badge object with no threshold
+        raises an IntegrityError exception.
+        """
+        badge = Badge(name="Sample Badge",
+                      description="This is a sample badge",
+                      threshold=None,
+                      type="conversationalist",
+                      image="path/too/image",
+                      date_created=timezone.now())
+
+        with self.assertRaises(IntegrityError):
+            with transaction.atomic():
+                badge.save()
+
+    def test_type_blank_raises_IntegrityError(self):
+        """
+        Trying to save a Badge object with no type
+        raises an IntegrityError exception.
+        """
+        badge = Badge(name="Sample Badge",
+                      description="This is a sample badge",
+                      threshold=30,
+                      type=None,
+                      image="path/too/image",
+                      date_created=timezone.now())
+
+        with self.assertRaises(IntegrityError):
+            with transaction.atomic():
+                badge.save()
+
+    def test_image_blank_raises_IntegrityError(self):
+        """
+        Trying to save a Badge object with no image path
+        raises an IntegrityError exception.
+        """
+        badge = Badge(name="Sample Badge",
+                      description="This is a sample badge",
+                      threshold=30,
+                      type="conversationalist",
+                      image=None,
+                      date_created=timezone.now())
+
+        with self.assertRaises(IntegrityError):
+            with transaction.atomic():
+                badge.save()
+
+    def test_date_blank_sets_current_date(self):
+        """
+        Trying to save a Badge object with no date_created
+        automatically sets it to current date.
+        """
+        badge_name = "Sample Badge"
+        badge = Badge(name=badge_name,
+                      description="This is a sample badge",
+                      threshold=30,
+                      type="conversationalist",
+                      image="path/to/image",
+                      date_created=None)
+        time_at_save = timezone.now().replace(microsecond=0)
+        badge.save()
+        saved_time = Badge.objects.get(name=badge_name).date_created.replace(microsecond=0)
+
+        self.assertEquals(time_at_save, saved_time)
+
+    def test_save_badge_normal(self):
+        """
+        Trying to save a Badge object with all the right arguments.
+        """
+        badge = Badge(name="Sample Badge",
+                      description="This is a sample badge",
+                      threshold=30,
+                      type="conversationalist",
+                      image="path/to/image",
+                      date_created=None)
+        self.assertEqual(badge.save(), None)
+
+    def test_remaining_badges_empty(self):
+        """
+        Get remaining badges dictionary without saving any
+        badges earlier so nothing matches
+        """
+        expected_result = {}
+        returned_result = Badge.get_unearned_badges(user_id=-1,
+                                                    community_id=-1,
+                                                    community_type="no_match_")
+        self.assertEqual(expected_result, returned_result)
+
+    def test_remaining_badges_none_earned(self):
+        """
+        Get remaining badges dictionary after saving badges
+        when none of the badges has been earned
+        """
+        badge_1 = Badge(name="badge_1", description="This is a sample badge",
+                        threshold=30, type="team", image="path/to/image")
+        badge_1.save()
+        badge_2 = Badge(name="badge_2", description="This is a sample badge",
+                        threshold=70, type="team", image="path/to/image")
+        badge_2.save()
+
+        expected_result = {}
+        expected_result["1"] = {'name': badge_1.name,
+                                'description': badge_1.description,
+                                'threshold': badge_1.threshold,
+                                'type': badge_1.type,
+                                'image': badge_1.image}
+        expected_result["2"] = {'name': badge_2.name,
+                                'description': badge_2.description,
+                                'threshold': badge_2.threshold,
+                                'type': badge_2.type,
+                                'image': badge_2.image}
+
+        actual_result = Badge.get_unearned_badges(user_id=-1,
+                                                  community_id=-1,
+                                                  community_type=TEAM_PLAYER[TEAM_PLAYER_ENTRY_INDEX])
+
+        self.assertEqual(len(actual_result), len(expected_result))
+
+        actual_result["1"] = actual_result.pop(actual_result.keys()[0])
+        actual_result["2"] = actual_result.pop(actual_result.keys()[1])
+
+        self.assertDictEqual(actual_result, expected_result)
+
+    def test_remaining_badges_one_earned(self):
+        """
+        Get remaining badges dictionary after saving badges
+        when user has already earned one of the badges
+        """
+        user = User.objects.create_user(username='testuser', password='12345')
+        badge_1 = Badge(name="badge_1", description="This is a sample badge",
+                        threshold=30, type="team", image="path/to/image")
+        badge_1.save()
+        badge_2 = Badge(name="badge_2", description="This is a sample badge",
+                        threshold=70, type="team", image="path/to/image")
+        badge_2.save()
+
+        UserBadge.objects.create(
+            user_id=user.id,
+            badge_id=badge_1.id,
+            course_id="",
+            community_id=-1
+        )
+
+        expected_result = {}
+        expected_result["1"] = {'name': badge_2.name,
+                                'description': badge_2.description,
+                                'threshold': badge_2.threshold,
+                                'type': badge_2.type,
+                                'image': badge_2.image}
+
+        actual_result = Badge.get_unearned_badges(user_id=user.id,
+                                                  community_id=-1,
+                                                  community_type=TEAM_PLAYER[TEAM_PLAYER_ENTRY_INDEX])
+
+        self.assertEqual(len(actual_result), len(expected_result))
+
+        actual_result["1"] = actual_result.pop(actual_result.keys()[0])
+
+        self.assertDictEqual(actual_result, expected_result)
+
+    def test_remaining_badges_all_earned(self):
+        """
+        Get remaining badges dictionary after saving badges
+        when user has already earned all of the badges
+        """
+        user = User.objects.create_user(username='testuser', password='12345')
+        badge_1 = Badge(name="badge_1", description="This is a sample badge",
+                        threshold=30, type="team", image="path/to/image")
+        badge_1.save()
+        badge_2 = Badge(name="badge_2", description="This is a sample badge",
+                        threshold=70, type="team", image="path/to/image")
+        badge_2.save()
+
+        UserBadge.objects.create(
+            user_id=user.id,
+            badge_id=badge_1.id,
+            course_id="",
+            community_id=-1
+        )
+
+        UserBadge.objects.create(
+            user_id=user.id,
+            badge_id=badge_2.id,
+            course_id="",
+            community_id=-1
+        )
+
+        expected_result = {}
+        actual_result = Badge.get_unearned_badges(user_id=user.id,
+                                                  community_id=-1,
+                                                  community_type=TEAM_PLAYER[TEAM_PLAYER_ENTRY_INDEX])
+
+        self.assertEqual(len(actual_result), len(expected_result))
+        self.assertDictEqual(actual_result, expected_result)

--- a/openedx/features/badging/tests/test_model_badge.py
+++ b/openedx/features/badging/tests/test_model_badge.py
@@ -13,105 +13,20 @@ from openedx.features.badging.constants import CONVERSATIONALIST, TEAM_PLAYER
 from openedx.features.badging.models import Badge, UserBadge
 
 
+def get_expected_badge_data(badge):
+    return {
+        'name': badge.name,
+        'description': badge.description,
+        'threshold': badge.threshold,
+        'type': badge.type,
+        'image': badge.image
+    }
+
+
 class BadgeModelTestCases(TestCase):
-    def test_name_blank_raises_IntegrityError(self):
-        """
-        Trying to save a Badge object with no name raises
-        an IntegrityError exception.
-        """
-        badge = Badge(name=None,
-                      description="This is a sample badge",
-                      threshold=30,
-                      type="conversationalist",
-                      image="path/too/image",
-                      date_created=timezone.now())
-
-        with self.assertRaises(IntegrityError):
-            with transaction.atomic():
-                badge.save()
-        badge.delete
-
-    def test_description_blank_no_exception(self):
-        """
-        Trying to save a Badge object with no description
-        does not raise any exception.
-        """
-        badge_name = "Sample Badge"
-        badge = Badge(name=badge_name,
-                      description=None,
-                      threshold=30,
-                      type="conversationalist",
-                      image="path/too/image",
-                      date_created=timezone.now())
-        badge.save()
-        saved_badge = Badge.objects.get(name=badge_name)
-        self.assertEquals(badge, saved_badge)
-
-    def test_threshold_blank_raises_IntegrityError(self):
-        """
-        Trying to save a Badge object with no threshold
-        raises an IntegrityError exception.
-        """
-        badge = Badge(name="Sample Badge",
-                      description="This is a sample badge",
-                      threshold=None,
-                      type="conversationalist",
-                      image="path/too/image",
-                      date_created=timezone.now())
-
-        with self.assertRaises(IntegrityError):
-            with transaction.atomic():
-                badge.save()
-
-    def test_type_blank_raises_IntegrityError(self):
-        """
-        Trying to save a Badge object with no type
-        raises an IntegrityError exception.
-        """
-        badge = Badge(name="Sample Badge",
-                      description="This is a sample badge",
-                      threshold=30,
-                      type=None,
-                      image="path/too/image",
-                      date_created=timezone.now())
-
-        with self.assertRaises(IntegrityError):
-            with transaction.atomic():
-                badge.save()
-
-    def test_image_blank_raises_IntegrityError(self):
-        """
-        Trying to save a Badge object with no image path
-        raises an IntegrityError exception.
-        """
-        badge = Badge(name="Sample Badge",
-                      description="This is a sample badge",
-                      threshold=30,
-                      type="conversationalist",
-                      image=None,
-                      date_created=timezone.now())
-
-        with self.assertRaises(IntegrityError):
-            with transaction.atomic():
-                badge.save()
-
-    def test_date_blank_sets_current_date(self):
-        """
-        Trying to save a Badge object with no date_created
-        automatically sets it to current date.
-        """
-        badge_name = "Sample Badge"
-        badge = Badge(name=badge_name,
-                      description="This is a sample badge",
-                      threshold=30,
-                      type="conversationalist",
-                      image="path/to/image",
-                      date_created=None)
-        time_at_save = timezone.now().replace(microsecond=0)
-        badge.save()
-        saved_time = Badge.objects.get(name=badge_name).date_created.replace(microsecond=0)
-
-        self.assertEquals(time_at_save, saved_time)
+    def setUp(self):
+        self.user = User.objects.create_user(username='testuser',
+                                             password='12345')
 
     def test_save_badge_normal(self):
         """
@@ -120,14 +35,14 @@ class BadgeModelTestCases(TestCase):
         badge = Badge(name="Sample Badge",
                       description="This is a sample badge",
                       threshold=30,
-                      type="conversationalist",
+                      type=CONVERSATIONALIST[CONVERSATIONALIST_ENTRY_INDEX],
                       image="path/to/image",
                       date_created=None)
         self.assertEqual(badge.save(), None)
 
-    def test_remaining_badges_empty(self):
+    def test_unearned_badges_empty(self):
         """
-        Get remaining badges dictionary without saving any
+        Get unearned badges dictionary without saving any
         badges earlier so nothing matches
         """
         expected_result = {}
@@ -136,29 +51,20 @@ class BadgeModelTestCases(TestCase):
                                                     community_type="no_match_")
         self.assertEqual(expected_result, returned_result)
 
-    def test_remaining_badges_none_earned(self):
+    def test_unearned_badges_none_earned(self):
         """
-        Get remaining badges dictionary after saving badges
+        Get unearned badges dictionary after saving badges
         when none of the badges has been earned
         """
-        badge_1 = Badge(name="badge_1", description="This is a sample badge",
-                        threshold=30, type="team", image="path/to/image")
-        badge_1.save()
-        badge_2 = Badge(name="badge_2", description="This is a sample badge",
-                        threshold=70, type="team", image="path/to/image")
-        badge_2.save()
-
+        badge_1 = Badge.objects.create(name="badge_1", description="This is a sample badge",
+                                       threshold=30, type=TEAM_PLAYER[TEAM_PLAYER_ENTRY_INDEX],
+                                       image="path/to/image")
+        badge_2 = Badge.objects.create(name="badge_2", description="This is a sample badge",
+                                       threshold=70, type=TEAM_PLAYER[TEAM_PLAYER_ENTRY_INDEX],
+                                       image="path/to/image")
         expected_result = {}
-        expected_result["1"] = {'name': badge_1.name,
-                                'description': badge_1.description,
-                                'threshold': badge_1.threshold,
-                                'type': badge_1.type,
-                                'image': badge_1.image}
-        expected_result["2"] = {'name': badge_2.name,
-                                'description': badge_2.description,
-                                'threshold': badge_2.threshold,
-                                'type': badge_2.type,
-                                'image': badge_2.image}
+        expected_result["1"] = get_expected_badge_data(badge_1)
+        expected_result["2"] = get_expected_badge_data(badge_2)
 
         actual_result = Badge.get_unearned_badges(user_id=-1,
                                                   community_id=-1,
@@ -171,34 +77,28 @@ class BadgeModelTestCases(TestCase):
 
         self.assertDictEqual(actual_result, expected_result)
 
-    def test_remaining_badges_one_earned(self):
+    def test_unearned_badges_one_earned(self):
         """
-        Get remaining badges dictionary after saving badges
+        Get unearned badges dictionary after saving badges
         when user has already earned one of the badges
         """
-        user = User.objects.create_user(username='testuser', password='12345')
-        badge_1 = Badge(name="badge_1", description="This is a sample badge",
-                        threshold=30, type="team", image="path/to/image")
-        badge_1.save()
-        badge_2 = Badge(name="badge_2", description="This is a sample badge",
-                        threshold=70, type="team", image="path/to/image")
-        badge_2.save()
-
+        badge_1 = Badge.objects.create(name="badge_1", description="This is a sample badge",
+                                       threshold=30, type=TEAM_PLAYER[TEAM_PLAYER_ENTRY_INDEX],
+                                       image="path/to/image")
+        badge_2 = Badge.objects.create(name="badge_2", description="This is a sample badge",
+                                       threshold=70, type=TEAM_PLAYER[TEAM_PLAYER_ENTRY_INDEX],
+                                       image="path/to/image")
         UserBadge.objects.create(
-            user_id=user.id,
+            user_id=self.user.id,
             badge_id=badge_1.id,
             course_id="",
             community_id=-1
         )
 
         expected_result = {}
-        expected_result["1"] = {'name': badge_2.name,
-                                'description': badge_2.description,
-                                'threshold': badge_2.threshold,
-                                'type': badge_2.type,
-                                'image': badge_2.image}
+        expected_result["1"] = get_expected_badge_data(badge_2)
 
-        actual_result = Badge.get_unearned_badges(user_id=user.id,
+        actual_result = Badge.get_unearned_badges(user_id=self.user.id,
                                                   community_id=-1,
                                                   community_type=TEAM_PLAYER[TEAM_PLAYER_ENTRY_INDEX])
 
@@ -208,35 +108,33 @@ class BadgeModelTestCases(TestCase):
 
         self.assertDictEqual(actual_result, expected_result)
 
-    def test_remaining_badges_all_earned(self):
+    def test_unearned_badges_all_earned(self):
         """
-        Get remaining badges dictionary after saving badges
+        Get unearned badges dictionary after saving badges
         when user has already earned all of the badges
         """
-        user = User.objects.create_user(username='testuser', password='12345')
-        badge_1 = Badge(name="badge_1", description="This is a sample badge",
-                        threshold=30, type="team", image="path/to/image")
-        badge_1.save()
-        badge_2 = Badge(name="badge_2", description="This is a sample badge",
-                        threshold=70, type="team", image="path/to/image")
-        badge_2.save()
-
+        badge_1 = Badge.objects.create(name="badge_1", description="This is a sample badge",
+                                       threshold=30, type=TEAM_PLAYER[TEAM_PLAYER_ENTRY_INDEX],
+                                       image="path/to/image")
+        badge_2 = Badge.objects.create(name="badge_2", description="This is a sample badge",
+                                       threshold=70, type=TEAM_PLAYER[TEAM_PLAYER_ENTRY_INDEX],
+                                       image="path/to/image")
         UserBadge.objects.create(
-            user_id=user.id,
+            user_id=self.user.id,
             badge_id=badge_1.id,
             course_id="",
             community_id=-1
         )
 
         UserBadge.objects.create(
-            user_id=user.id,
+            user_id=self.user.id,
             badge_id=badge_2.id,
             course_id="",
             community_id=-1
         )
 
         expected_result = {}
-        actual_result = Badge.get_unearned_badges(user_id=user.id,
+        actual_result = Badge.get_unearned_badges(user_id=self.user.id,
                                                   community_id=-1,
                                                   community_type=TEAM_PLAYER[TEAM_PLAYER_ENTRY_INDEX])
 

--- a/openedx/features/badging/tests/test_model_badge.py
+++ b/openedx/features/badging/tests/test_model_badge.py
@@ -1,16 +1,13 @@
 from django.contrib.auth.models import User
-from django.db import IntegrityError, transaction
 from django.test import TestCase
-from django.utils import timezone
 
 from common.djangoapps.nodebb.constants import (
-    COMMUNITY_ID_SPLIT_INDEX,
     TEAM_PLAYER_ENTRY_INDEX,
     CONVERSATIONALIST_ENTRY_INDEX
 )
 
 from openedx.features.badging.constants import CONVERSATIONALIST, TEAM_PLAYER
-from openedx.features.badging.models import Badge, UserBadge
+from openedx.features.badging.models import Badge
 
 from openedx.features.badging.tests.factories import BadgeFactory, UserBadgeFactory
 

--- a/openedx/features/badging/tests/test_model_userbadge.py
+++ b/openedx/features/badging/tests/test_model_userbadge.py
@@ -5,17 +5,7 @@ from django.db import IntegrityError, transaction
 from django.test import TestCase
 from django.utils import timezone
 
-from lms.djangoapps.teams.models import CourseTeam
 from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
-
-from common.djangoapps.nodebb.constants import (
-    COMMUNITY_ID_SPLIT_INDEX,
-    TEAM_PLAYER_ENTRY_INDEX,
-    CONVERSATIONALIST_ENTRY_INDEX
-)
-
-from nodebb.models import TeamGroupChat
-from openedx.features.badging.constants import CONVERSATIONALIST, TEAM_PLAYER
 from openedx.features.badging.models import Badge, UserBadge
 
 

--- a/openedx/features/badging/tests/test_model_userbadge.py
+++ b/openedx/features/badging/tests/test_model_userbadge.py
@@ -1,0 +1,178 @@
+from mock import patch
+
+from django.contrib.auth.models import User
+from django.db import IntegrityError, transaction
+from django.test import TestCase
+from django.utils import timezone
+
+from lms.djangoapps.teams.models import CourseTeam
+from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
+
+from common.djangoapps.nodebb.constants import (
+    COMMUNITY_ID_SPLIT_INDEX,
+    TEAM_PLAYER_ENTRY_INDEX,
+    CONVERSATIONALIST_ENTRY_INDEX
+)
+
+from nodebb.models import TeamGroupChat
+from openedx.features.badging.constants import CONVERSATIONALIST, TEAM_PLAYER
+from openedx.features.badging.models import Badge, UserBadge
+
+
+class UserBadgeModelTestCases(TestCase):
+
+    def setUp(self):
+        self.user = User.objects.create_user(username='testuser', password='12345')
+        self.badge_team = Badge(name="Sample Badge",
+                                description="This is a sample badge",
+                                threshold=30,
+                                type="team",
+                                image="path/too/image",
+                                date_created=timezone.now())
+        self.badge_team.save()
+
+        self.badge_convo = Badge(name="Sample Badge",
+                                 description="This is a sample badge",
+                                 threshold=30,
+                                 type="conversationalist",
+                                 image="path/too/image",
+                                 date_created=timezone.now())
+        self.badge_convo.save()
+
+    def test_save_userbadge_normal(self):
+        """
+        Trying to save a UserBadge object with expected arguments
+        """
+        userbadge = UserBadge(user=self.user,
+                              badge=self.badge_convo,
+                              course_id=CourseKeyField.Empty,
+                              community_id=-1,
+                              date_earned=timezone.now())
+
+        self.assertEqual(userbadge.save(), None)
+
+    def test_save_duplicate_badge(self):
+        """
+        Trying to save a duplicate UserBadge object with expected arguments
+
+        Raises IntegrityError upon trying to save the second object with
+        the same arguments
+        """
+        UserBadge.objects.create(user=self.user,
+                                 badge=self.badge_convo,
+                                 course_id=CourseKeyField.Empty,
+                                 community_id=-1,
+                                 date_earned=timezone.now())
+
+        with self.assertRaises(IntegrityError):
+            with transaction.atomic():
+                UserBadge.objects.create(user=self.user,
+                                         badge=self.badge_convo,
+                                         course_id=CourseKeyField.Empty,
+                                         community_id=-1,
+                                         date_earned=timezone.now())
+
+    def test_course_id_string(self):
+        """
+        Trying to save UserBadge object with course_id as string
+        """
+        self.assertTrue(UserBadge.objects.create(user=self.user,
+                                                 badge=self.badge_convo,
+                                                 course_id="",
+                                                 community_id=-1,
+                                                 date_earned=timezone.now()))
+
+    def test_community_id_None(self):
+        """
+        Trying to save UserBadge object with community_id as None
+        """
+        with self.assertRaises(IntegrityError):
+            with transaction.atomic():
+                UserBadge.objects.create(user=self.user,
+                                         badge=self.badge_convo,
+                                         course_id="",
+                                         community_id=None,
+                                         date_earned=timezone.now())
+
+    def test_date_blank_sets_current_date(self):
+        """
+        Trying to save a UserBadge object with no date_earned
+        automatically sets it to current date.
+        """
+        UserBadge.objects.create(user=self.user,
+                                 badge=self.badge_convo,
+                                 course_id=CourseKeyField.Empty,
+                                 community_id=-1,
+                                 date_earned=None)
+
+        time_at_save = timezone.now().replace(microsecond=0)
+        saved_time = UserBadge.objects.get(user=self.user).date_earned.replace(microsecond=0)
+        self.assertEquals(time_at_save, saved_time)
+
+    @patch('openedx.features.badging.models.get_course_id_by_community_id')
+    def test_assign_badge_wrong_badge_id(self, mock_get_community_id):
+        """
+        Trying to save a UserBadge object with badge id
+        that does not exist
+        """
+        mock_get_community_id.return_value = CourseKeyField.Empty
+
+        with self.assertRaises(Exception):
+            with transaction.atomic():
+                UserBadge.assign_badge(self.user.id, -1, "-1")
+
+    @patch('openedx.features.badging.models.get_course_id_by_community_id')
+    def test_assign_badge_wrong_type_discussion(self, mock_get_community_id):
+        """
+        Trying to save a UserBadge object giving a conversationalist
+        badge with a team community
+        """
+        mock_get_community_id.return_value = CourseKeyField.Empty
+        with self.assertRaises(Exception):
+            with transaction.atomic():
+                UserBadge.assign_badge(self.user.id, self.badge_convo.id, "-1")
+
+    @patch('openedx.features.badging.models.get_course_id_by_community_id')
+    def test_assign_badge_wrong_type_team(self, mock_get_community_id):
+        """
+        Trying to save a UserBadge object giving a team
+        badge with a conversationalist community
+        """
+        mock_get_community_id.return_value = "some_course_id"
+        with self.assertRaises(Exception):
+            with transaction.atomic():
+                UserBadge.assign_badge(self.user.id, self.badge_team.id, "-1")
+
+    @patch('openedx.features.badging.models.CourseTeamMembership.objects.filter')
+    @patch('openedx.features.badging.models.TeamGroupChat.objects.first')
+    @patch('openedx.features.badging.models.TeamGroupChat.objects.exclude')
+    @patch('openedx.features.badging.models.TeamGroupChat.objects.filter')
+    @patch('openedx.features.badging.models.get_course_id_by_community_id')
+    def test_assign_badge_team(self, mock_get_community_id, mock_team_group_filter,
+                               mock_team_group_exclude, mock_team_group_first,
+                               mock_course_team_filter):
+        """
+        Trying to save a UserBadge object assigning a team badge
+        successfully
+        """
+        mock_get_community_id.return_value = CourseKeyField.Empty
+        UserBadge.assign_badge(user_id=self.user.id,
+                               badge_id=self.badge_team.id,
+                               community_id=-1)
+
+        assert mock_team_group_filter.called
+        assert mock_course_team_filter.called
+
+    @patch('openedx.features.badging.models.UserBadge.objects.get_or_create')
+    @patch('openedx.features.badging.models.get_course_id_by_community_id')
+    def test_assign_badge_community(self, mock_get_community_id, mock_userbadge_create):
+        """
+        Trying to save a UserBadge object assigning a conversationalist
+        badge successfully
+        """
+        mock_get_community_id.return_value = "some_course_id"
+        UserBadge.assign_badge(user_id=self.user.id,
+                               badge_id=self.badge_convo.id,
+                               community_id=-1)
+
+        assert mock_userbadge_create.called

--- a/openedx/features/badging/tests/test_model_userbadge.py
+++ b/openedx/features/badging/tests/test_model_userbadge.py
@@ -23,21 +23,19 @@ class UserBadgeModelTestCases(TestCase):
 
     def setUp(self):
         self.user = User.objects.create_user(username='testuser', password='12345')
-        self.badge_team = Badge(name="Sample Badge",
-                                description="This is a sample badge",
-                                threshold=30,
-                                type="team",
-                                image="path/too/image",
-                                date_created=timezone.now())
-        self.badge_team.save()
+        self.badge_team = Badge.objects.create(name="Sample Badge",
+                                               description="This is a sample badge",
+                                               threshold=30,
+                                               type="team",
+                                               image="path/too/image",
+                                               date_created=timezone.now())
 
-        self.badge_convo = Badge(name="Sample Badge",
-                                 description="This is a sample badge",
-                                 threshold=30,
-                                 type="conversationalist",
-                                 image="path/too/image",
-                                 date_created=timezone.now())
-        self.badge_convo.save()
+        self.badge_convo = Badge.objects.create(name="Sample Badge",
+                                                description="This is a sample badge",
+                                                threshold=30,
+                                                type="conversationalist",
+                                                image="path/too/image",
+                                                date_created=timezone.now())
 
     def test_save_userbadge_normal(self):
         """
@@ -93,21 +91,6 @@ class UserBadgeModelTestCases(TestCase):
                                          course_id="",
                                          community_id=None,
                                          date_earned=timezone.now())
-
-    def test_date_blank_sets_current_date(self):
-        """
-        Trying to save a UserBadge object with no date_earned
-        automatically sets it to current date.
-        """
-        UserBadge.objects.create(user=self.user,
-                                 badge=self.badge_convo,
-                                 course_id=CourseKeyField.Empty,
-                                 community_id=-1,
-                                 date_earned=None)
-
-        time_at_save = timezone.now().replace(microsecond=0)
-        saved_time = UserBadge.objects.get(user=self.user).date_earned.replace(microsecond=0)
-        self.assertEquals(time_at_save, saved_time)
 
     @patch('openedx.features.badging.models.get_course_id_by_community_id')
     def test_assign_badge_wrong_badge_id(self, mock_get_community_id):


### PR DESCRIPTION
[`assign_badge`, `get_unearned_badges`] Coverage for openedx/features/badging/models.py : 93%
[`assign_user_badge`] Coverage for lms/djangoapps/philu_api/views.py : 100%