### PR TITLE
Reordering student migration dependencies to fix migration issues

### DIFF
--- a/common/djangoapps/student/migrations/0009_auto_20170111_0422.py
+++ b/common/djangoapps/student/migrations/0009_auto_20170111_0422.py
@@ -7,7 +7,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('student', '0008_auto_20161117_1209'),
+        ('student', '0017_auto_20171219_0925'),
     ]
 
     operations = [

--- a/common/djangoapps/student/migrations/0016_historicaluserprofile.py
+++ b/common/djangoapps/student/migrations/0016_historicaluserprofile.py
@@ -11,7 +11,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
-        ('student', '0019_auto_20181221_0540'),
+        ('student', '0008_auto_20161117_1209'),
     ]
 
     operations = [


### PR DESCRIPTION
Reordering student migration dependencies to fix migration issues

**Context:**
When migration was run on ironwood with ficus dev databases, this was the one of the three issues encounter. `0016_historicaluserprofile` and `0017_auto_20171219_0925` are migrations which were already executed on ficus but after ironwood upgraded, dependence of `0016_historicaluserprofile` automatically changed to `0019_auto_20181221_0540`. Migration 0019 is new, so an already executed migration cannot have dependence on migration which is not yet executed, hence the error. 

**Fix:**
Moving `0016_historicaluserprofile` and `0017_auto_20171219_0925` above in dependency chain. These migrations will execute after `0008_auto_20161117_1209` and before `0009_auto_20170111_0422`.

