### PR TITLE
LP-872 Creating PDF certificate

### DIFF
--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -48,7 +48,7 @@ from student.models import LinkedInAddToProfileConfiguration
 from util import organizations_helpers as organization_api
 from util.date_utils import strftime_localized
 from util.views import handle_500
-from lms.djangoapps.philu_overrides.certificates.webview import override_update_social_context
+from lms.djangoapps.philu_overrides.certificates.webview import override_update_certificate_context
 
 
 log = logging.getLogger(__name__)
@@ -591,7 +591,7 @@ def render_html_view(request, user_id, course_id):
 
         # Append social sharing info
         # _update_social_context(request, context, course, user, user_certificate, platform_name)
-        override_update_social_context(request, context, course, user, user_certificate, platform_name)
+        override_update_certificate_context(request, context, course, user, user_certificate, platform_name)
 
         # Append/Override the existing view context values with certificate specific values
         _update_certificate_context(context, course, user_certificate, platform_name)

--- a/lms/djangoapps/philu_overrides/certificates/webview.py
+++ b/lms/djangoapps/philu_overrides/certificates/webview.py
@@ -1,11 +1,13 @@
 from openedx.features.student_certificates.helpers import get_philu_certificate_social_context
+from django.urls import reverse
 
-
-def override_update_social_context(request, context, course, user, user_certificate, platform_name):
+def override_update_certificate_context(request, context, course, user, user_certificate, platform_name):
     border = request.GET.get('border', None)
     if border and border == 'hide':
         context['border_class'] = 'certificate-border-hide'
     else:
         context['border_class'] = ''
 
+    context['download_pdf'] = reverse('download_certificate_pdf',
+                                      kwargs={'certificate_uuid': user_certificate.verify_uuid})
     context['social_sharing_urls'] = get_philu_certificate_social_context(course, user_certificate)

--- a/lms/djangoapps/philu_overrides/certificates/webview.py
+++ b/lms/djangoapps/philu_overrides/certificates/webview.py
@@ -1,6 +1,7 @@
 from openedx.features.student_certificates.helpers import get_philu_certificate_social_context
 from django.urls import reverse
 
+
 def override_update_certificate_context(request, context, course, user, user_certificate, platform_name):
     border = request.GET.get('border', None)
     if border and border == 'hide':

--- a/openedx/features/student_certificates/constants.py
+++ b/openedx/features/student_certificates/constants.py
@@ -4,3 +4,22 @@ TWITTER_TWEET_TEXT_FMT = 'I just completed @PhilanthropyUni\'s free online {cour
 TWITTER_META_TITLE_FMT = "I just completed Philanthropy University\'s {course_name} course!"
 SOCIAL_MEDIA_SHARE_URL_FMT = "{base_url}/achievements/{certificate_uuid}"
 COURSE_URL_FMT = "{base_url}/{course_url}/{course_id}/{about_url}"
+PAGE_HEIGHT='page-height'
+PAGE_WIDTH='page-width'
+PDF_RESPONSE_HEADER = 'attachment; filename="{certificate_pdf_name}.pdf"' # download pdf for end user
+PDFKIT_HTML_STRING='<html><head><style>body,html{{padding:0;margin:0;font-size:0;}}</style></head><body>{image_tag}</body></html>'
+PDFKIT_IMAGE_PATH = False # Use false instead of output path to save pdf to a python variable
+PDFKIT_IMAGE_TAG='<img src="data:image/png;base64,{base64_img}"/>'
+PDFKIT_OPTIONS = {
+    PAGE_HEIGHT: '{}px',
+    PAGE_WIDTH: '{}px',
+    'disable-smart-shrinking': None,  # By default pdfkit scale/shrink html, in our case we do not need that
+    'encoding': "UTF-8",
+    'margin-bottom': '0.0in',
+    'margin-left': '0.0in',
+    'margin-right': '0.0in',
+    'margin-top': '0.0in',
+    'no-outline': None,
+    'print-media-type': None
+}
+TMPDIR="/tmp" # path of directory to store files (certificate images) temporarily

--- a/openedx/features/student_certificates/helpers.py
+++ b/openedx/features/student_certificates/helpers.py
@@ -32,10 +32,18 @@ def get_certificate_image_url(certificate):
     :param certificate:
     :return: return s3 url of corresponding image of the certificate
     """
+    return get_certificate_image_url_by_uuid(certificate.verify_uuid)
+
+
+def get_certificate_image_url_by_uuid(verify_uuid):
+    """
+    :param certificate uuid:
+    :return: return s3 url of corresponding image of the certificate
+    """
     return 'https://s3.amazonaws.com/{bucket}/{prefix}/{uuid}.jpg'.format(
         bucket=getattr(settings, "FILE_UPLOAD_STORAGE_BUCKET_NAME", None),
         prefix=CERTIFICATE_IMG_PREFIX,
-        uuid=certificate.verify_uuid
+        uuid=verify_uuid
     )
 
 

--- a/openedx/features/student_certificates/urls.py
+++ b/openedx/features/student_certificates/urls.py
@@ -9,4 +9,7 @@ urlpatterns = [
     url(r"^certificates/$", views.student_certificates, name="certificates"),
     url(r"^achievements/(?P<certificate_uuid>[0-9a-f]{32})$", views.shared_student_achievements,
         name="shared_achievements"),
+    url(r'^(?P<certificate_uuid>[0-9a-f]{32})/download', views.download_certificate_pdf,
+        name='download_certificate_pdf'
+    ),
 ]

--- a/openedx/features/student_certificates/urls.py
+++ b/openedx/features/student_certificates/urls.py
@@ -9,7 +9,7 @@ urlpatterns = [
     url(r"^certificates/$", views.student_certificates, name="certificates"),
     url(r"^achievements/(?P<certificate_uuid>[0-9a-f]{32})$", views.shared_student_achievements,
         name="shared_achievements"),
-    url(r'^(?P<certificate_uuid>[0-9a-f]{32})/download', views.download_certificate_pdf,
+    url(r'^certificates/(?P<certificate_uuid>[0-9a-f]{32})/download$', views.download_certificate_pdf,
         name='download_certificate_pdf'
     ),
 ]

--- a/requirements/philu/base.txt
+++ b/requirements/philu/base.txt
@@ -7,6 +7,7 @@ pyminizip==0.2.1
 channels==1.1.8
 asgi-redis==1.4.3
 imgkit==1.0.1
+pdfkit==0.6.1
 -e git+https://github.com/philanthropy-u/xblock-poll#egg=xblock-poll
 -e git+https://github.com/philanthropy-u/edx-notifications.git@9c602923d0e8a7b512a52bc4d0df5c7043286386#egg=edx-notifications
 -e git+https://github.com/philanthropy-u/django-simple-history.git@9187c9b4907da5a2a0564eff45929fd15b784309#egg=django-simple-history


### PR DESCRIPTION
## [LP-872](https://philanthropyu.atlassian.net/browse/LP-872)

- Create download/save as PDF functionality for certificates
- Django admin template for certificate is updated. See [PR-958](https://github.com/philanthropy-u/philu-edx-theme/pull/958) in theme
- [pdfkit](https://pypi.org/project/pdfkit/) dependency added
- [wkhtmltopdf](https://wkhtmltopdf.org/) version **0.12.5** installed in virtual environment, it is pre-requisite for pdfkit 