### PR TITLE
[LP-1630] Fixed exception in VisibleBlocks.bulk_create due to incorrect argument passed

### DIFF
--- a/lms/djangoapps/grades/models.py
+++ b/lms/djangoapps/grades/models.py
@@ -223,7 +223,7 @@ class VisibleBlocks(models.Model):
         only for those that aren't already created.
         """
         cached_records = cls.bulk_read(user_id, course_key)
-        non_existent_brls = {brl.hash_value for brl in block_record_lists if brl.hash_value not in cached_records}
+        non_existent_brls = {brl for brl in block_record_lists if brl.hash_value not in cached_records}
         cls.bulk_create(user_id, course_key, non_existent_brls)
 
     @classmethod


### PR DESCRIPTION
replaced brl.hash_value with brl in bulk_get_or_create because it calls bulk_create afterwards and bulk_create uses objects to create VisibleBlocks whereas brl.hash_value would return a string