### PR TITLE
mabdullahz/LP-1631 [BUG]: "Resend Activation Email" option is not available on Community side

### DIFF
--- a/lms/djangoapps/philu_api/views.py
+++ b/lms/djangoapps/philu_api/views.py
@@ -260,18 +260,19 @@ def send_alquity_fake_confirmation_email(request):
 
 
 @csrf_exempt
+@require_POST
 def resend_activation_email(request):
     data = json.loads(request.body)
     user_id = data.get('user_id')
-    user = User.objects.get(id=user_id)
-    activated = user.is_active
     try:
+        user = User.objects.get(id=user_id)
+        activated = user.is_active
         if not activated:
             reactivation_email_for_user_custom(request, user)
-            return JsonResponse({'success': True, 'email': user.email}, status=status.HTTP_200_OK)
+            return JsonResponse({'email': user.email}, status=status.HTTP_200_OK)
         else:
             # the user's account has already been activated
-            return JsonResponse({'success': False}, status=status.HTTP_409_CONFLICT)
+            return JsonResponse({}, status=status.HTTP_409_CONFLICT)
     except Exception as ex:
         logging.exception(ex)
-        return JsonResponse({'success': False}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        return JsonResponse({}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)

--- a/lms/djangoapps/philu_api/views.py
+++ b/lms/djangoapps/philu_api/views.py
@@ -259,8 +259,11 @@ def send_alquity_fake_confirmation_email(request):
     return JsonResponse({'success': success})
 
 
+@csrf_exempt
 def resend_activation_email(request):
-    user = request.user
+    data = json.loads(request.body)
+    user_id = data.get('user_id')
+    user = User.objects.get(id=user_id)
     activated = user.is_active
     try:
         if not activated:

--- a/lms/djangoapps/philu_overrides/constants.py
+++ b/lms/djangoapps/philu_overrides/constants.py
@@ -1,4 +1,4 @@
-ACTIVATION_ERROR_MSG_FORMAT = '<span id="resend-activation-span"> Your account has not been activated. Please check your email to activate your account. <a id="resend-activation-link" class="click-here-link" href="{}" data-user-id={}> Resend Activation Email </a></span>'
+ACTIVATION_ERROR_MSG_FORMAT = '<span id="resend-activation-span"> Your account has not been activated. Please check your email to activate your account. <a id="resend-activation-link" class="click-here-link" href="{api_endpoint}" data-user-id={user_id}> Resend Activation Email </a></span>'
 
 ORG_DETAILS_UPDATE_ALERT = 'It has been more than a year since you updated these numbers. Are they still correct?'
 ORG_OEF_UPDATE_ALERT = 'It has been more than a year since you submitted your OEF assessment. Time to submit a new one!'

--- a/lms/djangoapps/philu_overrides/constants.py
+++ b/lms/djangoapps/philu_overrides/constants.py
@@ -1,4 +1,4 @@
-ACTIVATION_ERROR_MSG_FORMAT = '<span id="resend-activation-span"> Your account has not been activated. Please check your email to activate your account. <a id="resend-activation-link" class="click-here-link" href="{}"> Resend Activation Email </a></span>'
+ACTIVATION_ERROR_MSG_FORMAT = '<span id="resend-activation-span"> Your account has not been activated. Please check your email to activate your account. <a id="resend-activation-link" class="click-here-link" href="{}" data-user-id={}> Resend Activation Email </a></span>'
 
 ORG_DETAILS_UPDATE_ALERT = 'It has been more than a year since you updated these numbers. Are they still correct?'
 ORG_OEF_UPDATE_ALERT = 'It has been more than a year since you submitted your OEF assessment. Time to submit a new one!'

--- a/lms/djangoapps/philu_overrides/context_processor.py
+++ b/lms/djangoapps/philu_overrides/context_processor.py
@@ -31,7 +31,7 @@ def get_global_alert_messages(request):
         if request.user.is_authenticated() and not request.user.is_active and '/activate/' not in request.path:
             alert_messages.append({
                 "type": ACTIVATION_ALERT_TYPE,
-                "alert": ACTIVATION_ERROR_MSG_FORMAT.format(reverse('resend_activation_email'), request.user.id)
+                "alert": ACTIVATION_ERROR_MSG_FORMAT.format(api_endpoint=reverse('resend_activation_email'), user_id=request.user.id)
             })
 
     if '/oef/dashboard' in request.path:

--- a/lms/djangoapps/philu_overrides/context_processor.py
+++ b/lms/djangoapps/philu_overrides/context_processor.py
@@ -31,7 +31,7 @@ def get_global_alert_messages(request):
         if request.user.is_authenticated() and not request.user.is_active and '/activate/' not in request.path:
             alert_messages.append({
                 "type": ACTIVATION_ALERT_TYPE,
-                "alert": ACTIVATION_ERROR_MSG_FORMAT.format(reverse('resend_activation_email'))
+                "alert": ACTIVATION_ERROR_MSG_FORMAT.format(reverse('resend_activation_email'), request.user.id)
             })
 
     if '/oef/dashboard' in request.path:


### PR DESCRIPTION
**Problem**: Resend activation email button was enabled on LMS side, but had to be separately enabled in NodeBB

**Resolution**: 

1. **`views.py`**: `csrf_exempt` decorator was used since the django requires that the token is sent in request headers. The request from NodeBB falls under CORS request and hence, that requests is forbidden at edX side. Also, the `user_id` is now being sent in body of the request from both the sides. 

2. **`constants.py`**: `user id` is being sent as a data attribute to edX side to be sent in AJAX request body.

3.  **`context_processor.py`**: `user id` inserted in the alert format-able string to be used by AJAX request