### PR TITLE
mabdullahz/LP-1619: Add "Resend Activation Email" button to site banner

### DIFF
--- a/lms/djangoapps/onboarding/constants.py
+++ b/lms/djangoapps/onboarding/constants.py
@@ -1,4 +1,7 @@
 ACTIVATION_ERROR = 'Your account has not been activated. Please check your email to activate your account.'
+ACTIVATION_RESEND_LINK = '<a id="resend-activation-link" href="/philu/api/resend_activation_email/"> Resend Activation Email </a>'
+ACTIVATION_BANNER_ID = 'email-activation-banner'
+
 ORG_PARTNERSHIP_END_DATE_PLACEHOLDER = '3000-01-01'
 
 REMIND_ME_LATER_KEY = 'RML'

--- a/lms/djangoapps/onboarding/constants.py
+++ b/lms/djangoapps/onboarding/constants.py
@@ -1,7 +1,4 @@
 ACTIVATION_ERROR = 'Your account has not been activated. Please check your email to activate your account.'
-ACTIVATION_RESEND_LINK = '<a id="resend-activation-link" href="/philu/api/resend_activation_email/"> Resend Activation Email </a>'
-ACTIVATION_BANNER_ID = 'email-activation-banner'
-
 ORG_PARTNERSHIP_END_DATE_PLACEHOLDER = '3000-01-01'
 
 REMIND_ME_LATER_KEY = 'RML'

--- a/lms/djangoapps/philu_api/urls.py
+++ b/lms/djangoapps/philu_api/urls.py
@@ -6,7 +6,7 @@ from django.conf.urls import url
 from lms.djangoapps.philu_api.views import PlatformSyncService, \
     get_user_chat, mark_user_chat_read, get_user_data, MailChimpDataSyncAPI, \
     ThirdPartyResultDataSyncAPI, download_pdf_file, send_alquity_fake_confirmation_email, \
-    UpdatePromptClickRecord, assign_user_badge
+    UpdatePromptClickRecord, assign_user_badge, resend_activation_email
 
 urlpatterns = [
     url(r'platform/sync/service/', PlatformSyncService.as_view(), name='get_shared_data'),
@@ -20,4 +20,5 @@ urlpatterns = [
     url(r'send_alquity_email/$', send_alquity_fake_confirmation_email, name='send_alquity_fake_confirmation_email'),
     url(r'record_prompt_click/$', UpdatePromptClickRecord.as_view(), name='record_prompt_click'),
     url(r'assign_badge/$', assign_user_badge, name='assign_user_badge'),
+    url(r'resend_activation_email/$', resend_activation_email, name='resend_activation_email'),
 ]

--- a/lms/djangoapps/philu_api/views.py
+++ b/lms/djangoapps/philu_api/views.py
@@ -260,18 +260,19 @@ def send_alquity_fake_confirmation_email(request):
 
 
 @csrf_exempt
+@require_POST
 def resend_activation_email(request):
     data = json.loads(request.body)
     user_id = data.get('user_id')
-    user = User.objects.get(id=user_id)
-    activated = user.is_active
     try:
+        user = User.objects.get(id=user_id)
+        activated = user.is_active
         if not activated:
             reactivation_email_for_user_custom(request, user)
-            return JsonResponse({'success': True, 'email': user.email}, status=status.HTTP_200_OK)
+            return JsonResponse({'email': user.email}, status=status.HTTP_200_OK)
         else:
             # the user's account has already been activated
-            return JsonResponse({'success': False}, status=status.HTTP_409_CONFLICT)
+            return JsonResponse({}, status=status.HTTP_409_CONFLICT)
     except Exception as ex:
         logging.exception(ex)
-        return JsonResponse({'success': False}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        return JsonResponse({}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)

--- a/lms/djangoapps/philu_api/views.py
+++ b/lms/djangoapps/philu_api/views.py
@@ -262,17 +262,20 @@ def send_alquity_fake_confirmation_email(request):
 @csrf_exempt
 @require_POST
 def resend_activation_email(request):
-    data = json.loads(request.body)
-    user_id = data.get('user_id')
     try:
+        data = json.loads(request.body)
+        user_id = data.get('user_id')
         user = User.objects.get(id=user_id)
         activated = user.is_active
         if not activated:
             reactivation_email_for_user_custom(request, user)
-            return JsonResponse({'email': user.email}, status=status.HTTP_200_OK)
+            activation_response = JsonResponse(data={'email': user.email}, status=status.HTTP_200_OK)
         else:
             # the user's account has already been activated
-            return JsonResponse({}, status=status.HTTP_409_CONFLICT)
+            activation_response = JsonResponse(data = {}, status=status.HTTP_409_CONFLICT)
     except Exception as ex:
         logging.exception(ex)
-        return JsonResponse({}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        activation_response = JsonResponse(data = {}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+    activation_response["Access-Control-Allow-Origin"] = settings.NODEBB_ENDPOINT
+    return activation_response

--- a/lms/djangoapps/philu_api/views.py
+++ b/lms/djangoapps/philu_api/views.py
@@ -16,6 +16,8 @@ from mailchimp_pipeline.tasks import update_enrollments_completions_at_mailchimp
 from lms.djangoapps.onboarding.helpers import get_org_metric_update_prompt
 from lms.djangoapps.onboarding.models import MetricUpdatePromptRecord
 from student.models import User
+from philu_overrides.helpers import reactivation_email_for_user_custom
+
 import urllib
 import json
 from django.http import HttpResponse, Http404
@@ -254,3 +256,15 @@ def send_alquity_fake_confirmation_email(request):
         logging.exception(ex)
         success = False
     return JsonResponse({'success': success})
+
+
+def resend_activation_email(request):
+    user = request.user
+    success = True
+    try:
+        if not activated:
+            reactivation_email_for_user_custom(request, user)
+    except Exception as ex:
+        logging.exception(ex)
+        success = False
+    return JsonResponse({'success': success, 'email': user.email})

--- a/lms/djangoapps/philu_api/views.py
+++ b/lms/djangoapps/philu_api/views.py
@@ -259,8 +259,11 @@ def send_alquity_fake_confirmation_email(request):
     return JsonResponse({'success': success})
 
 
+@csrf_exempt
 def resend_activation_email(request):
-    user = request.user
+    data = json.loads(request.body)
+    user_id = data.get('user_id')
+    user = User.objects.get(id=user_id)
     activated = user.is_active
     try:
         if not activated:

--- a/lms/djangoapps/philu_api/views.py
+++ b/lms/djangoapps/philu_api/views.py
@@ -277,5 +277,4 @@ def resend_activation_email(request):
         logging.exception(ex)
         activation_response = JsonResponse(data = {}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
-    activation_response["Access-Control-Allow-Origin"] = settings.NODEBB_ENDPOINT
     return activation_response

--- a/lms/djangoapps/philu_api/views.py
+++ b/lms/djangoapps/philu_api/views.py
@@ -1,34 +1,35 @@
 """
 restAPI Views
 """
+import json
 import logging
 import requests
-from celery.result import AsyncResult
-from common.lib.mandrill_client.client import MandrillClient
-from django.http import JsonResponse
-from django.conf import settings
-from lms.djangoapps.third_party_surveys.tasks import get_third_party_surveys_task
+import urllib
+
 from rest_framework import status
 from rest_framework.views import APIView
-from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
-
-from mailchimp_pipeline.tasks import update_enrollments_completions_at_mailchimp
-from lms.djangoapps.onboarding.helpers import get_org_metric_update_prompt
-from lms.djangoapps.onboarding.models import MetricUpdatePromptRecord
-from student.models import User
-
-import urllib
-import json
-from django.http import HttpResponse, Http404
-from django.views.decorators.http import require_POST
-from django.views.decorators.csrf import csrf_exempt
+from util.json_request import expect_json
 from wsgiref.util import FileWrapper
 
-from lms.djangoapps.oef.decorators import eligible_for_oef
-from lms.djangoapps.philu_api.helpers import get_encoded_token
+from django.conf import settings
+from django.http import JsonResponse, HttpResponse, Http404
+from django.views.decorators.http import require_POST
+from django.views.decorators.csrf import csrf_exempt
+
+from celery.result import AsyncResult
+from common.lib.mandrill_client.client import MandrillClient
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.features.badging.models import Badge, UserBadge
+
+from lms.djangoapps.oef.decorators import eligible_for_oef
+from lms.djangoapps.onboarding.helpers import get_org_metric_update_prompt
+from lms.djangoapps.onboarding.models import MetricUpdatePromptRecord
+from lms.djangoapps.philu_api.helpers import get_encoded_token
+from lms.djangoapps.third_party_surveys.tasks import get_third_party_surveys_task
+
+from mailchimp_pipeline.tasks import update_enrollments_completions_at_mailchimp
+from student.models import User
 from philu_overrides.helpers import reactivation_email_for_user_custom
-from util.json_request import expect_json
 
 
 log = logging.getLogger("edx.philu_api")
@@ -266,6 +267,7 @@ def resend_activation_email(request):
             reactivation_email_for_user_custom(request, user)
             return JsonResponse({'success': True, 'email': user.email}, status=status.HTTP_200_OK)
         else:
+            # the user's account has already been activated
             return JsonResponse({'success': False}, status=status.HTTP_409_CONFLICT)
     except Exception as ex:
         logging.exception(ex)

--- a/lms/djangoapps/philu_overrides/constants.py
+++ b/lms/djangoapps/philu_overrides/constants.py
@@ -1,4 +1,4 @@
-ACTIVATION_ERROR_MSG_FORMAT = '<span id="resend-activation-span"> Your account has not been activated. Please check your email to activate your account. <a id="resend-activation-link" class="click-here-link" href="{}" data-user-id={}> Resend Activation Email </a></span>'
+ACTIVATION_ERROR_MSG_FORMAT = '<span id="resend-activation-span"> Your account has not been activated. Please check your email to activate your account. <a id="resend-activation-link" class="click-here-link" href="{api_endpoint}" data-user-id={user_id}> Resend Activation Email </a></span>'
 
 ORG_DETAILS_UPDATE_ALERT = 'It has been more than a year since you updated these numbers. Are they still correct?'
 ORG_OEF_UPDATE_ALERT = 'It has been more than a year since you submitted your OEF assessment. Time to submit a new one!'

--- a/lms/djangoapps/philu_overrides/constants.py
+++ b/lms/djangoapps/philu_overrides/constants.py
@@ -1,4 +1,4 @@
-ACTIVATION_ERROR_MSG_FORMAT = '<span id="resend-activation-span"> Your account has not been activated. Please check your email to activate your account. <a id="resend-activation-link" href="{}"> Resend Activation Email </a></span>'
+ACTIVATION_ERROR_MSG_FORMAT = '<span id="resend-activation-span"> Your account has not been activated. Please check your email to activate your account. <a id="resend-activation-link" class="click-here-link" href="{}"> Resend Activation Email </a></span>'
 
 ORG_DETAILS_UPDATE_ALERT = 'It has been more than a year since you updated these numbers. Are they still correct?'
 ORG_OEF_UPDATE_ALERT = 'It has been more than a year since you submitted your OEF assessment. Time to submit a new one!'

--- a/lms/djangoapps/philu_overrides/constants.py
+++ b/lms/djangoapps/philu_overrides/constants.py
@@ -1,4 +1,7 @@
 ACTIVATION_ERROR = 'Your account has not been activated. Please check your email to activate your account.'
+ACTIVATION_RESEND_LINK = '<a id="resend-activation-link" href="/philu/api/resend_activation_email/"> Resend Activation Email </a>'
+ACTIVATION_BANNER_ID = 'email-activation-banner'
+
 ORG_DETAILS_UPDATE_ALERT = 'It has been more than a year since you updated these numbers. Are they still correct?'
 ORG_OEF_UPDATE_ALERT = 'It has been more than a year since you submitted your OEF assessment. Time to submit a new one!'
 ACTIVATION_ALERT_TYPE = 'activation'

--- a/lms/djangoapps/philu_overrides/constants.py
+++ b/lms/djangoapps/philu_overrides/constants.py
@@ -1,6 +1,7 @@
 ACTIVATION_ERROR = 'Your account has not been activated. Please check your email to activate your account.'
-ACTIVATION_RESEND_LINK = '<a id="resend-activation-link" href="/philu/api/resend_activation_email/"> Resend Activation Email </a>'
 ACTIVATION_BANNER_ID = 'email-activation-banner'
+ACTIVATION_LINK_ID = 'resend-activation-link'
+ACTIVATION_RESEND_LINK = '<a id="{}" href="/philu/api/resend_activation_email/"> Resend Activation Email </a>'.format(ACTIVATION_LINK_ID)
 
 ORG_DETAILS_UPDATE_ALERT = 'It has been more than a year since you updated these numbers. Are they still correct?'
 ORG_OEF_UPDATE_ALERT = 'It has been more than a year since you submitted your OEF assessment. Time to submit a new one!'

--- a/lms/djangoapps/philu_overrides/constants.py
+++ b/lms/djangoapps/philu_overrides/constants.py
@@ -1,7 +1,4 @@
-ACTIVATION_ERROR = 'Your account has not been activated. Please check your email to activate your account.'
-ACTIVATION_BANNER_ID = 'email-activation-banner'
-ACTIVATION_LINK_ID = 'resend-activation-link'
-ACTIVATION_RESEND_LINK = '<a id="{}" href="/philu/api/resend_activation_email/"> Resend Activation Email </a>'.format(ACTIVATION_LINK_ID)
+ACTIVATION_ERROR_MSG_FORMAT = '<span id="resend-activation-span"> Your account has not been activated. Please check your email to activate your account. <a id="resend-activation-link" href="{}"> Resend Activation Email </a></span>'
 
 ORG_DETAILS_UPDATE_ALERT = 'It has been more than a year since you updated these numbers. Are they still correct?'
 ORG_OEF_UPDATE_ALERT = 'It has been more than a year since you submitted your OEF assessment. Time to submit a new one!'

--- a/lms/djangoapps/philu_overrides/constants.py
+++ b/lms/djangoapps/philu_overrides/constants.py
@@ -1,4 +1,4 @@
-ACTIVATION_ERROR_MSG_FORMAT = '<span id="resend-activation-span"> Your account has not been activated. Please check your email to activate your account. <a id="resend-activation-link" class="click-here-link" href="{}"> Resend Activation Email </a></span>'
+ACTIVATION_ERROR_MSG_FORMAT = '<span id="resend-activation-span"> Your account has not been activated. Please check your email to activate your account. <a id="resend-activation-link" class="click-here-link" href="{}" data-user-id={}> Resend Activation Email </a></span>'
 
 ORG_DETAILS_UPDATE_ALERT = 'It has been more than a year since you updated these numbers. Are they still correct?'
 ORG_OEF_UPDATE_ALERT = 'It has been more than a year since you submitted your OEF assessment. Time to submit a new one!'

--- a/lms/djangoapps/philu_overrides/context_processor.py
+++ b/lms/djangoapps/philu_overrides/context_processor.py
@@ -31,7 +31,7 @@ def get_global_alert_messages(request):
         if request.user.is_authenticated() and not request.user.is_active and '/activate/' not in request.path:
             alert_messages.append({
                 "type": ACTIVATION_ALERT_TYPE,
-                "alert": ACTIVATION_ERROR_MSG_FORMAT.format(reverse('resend_activation_email'), request.user.id)
+                "alert": ACTIVATION_ERROR_MSG_FORMAT.format(api_endpoint=reverse('resend_activation_email'), user_id=request.user.id)
             })
 
     if '/oef/dashboard' in request.path:

--- a/lms/djangoapps/philu_overrides/context_processor.py
+++ b/lms/djangoapps/philu_overrides/context_processor.py
@@ -1,10 +1,11 @@
 from django.conf import settings
+from django.urls import reverse
 
 from lms.djangoapps.onboarding.helpers import get_org_metric_update_prompt, \
     is_org_detail_prompt_available, is_org_detail_platform_overlay_available, \
     get_org_oef_update_prompt, is_org_oef_prompt_available
-from lms.djangoapps.philu_overrides.constants import ACTIVATION_ERROR, ACTIVATION_ALERT_TYPE, \
-    ACTIVATION_RESEND_LINK, ORG_DETAILS_UPDATE_ALERT, ORG_OEF_UPDATE_ALERT, ACTIVATION_BANNER_ID
+from lms.djangoapps.philu_overrides.constants import ACTIVATION_ALERT_TYPE, ACTIVATION_ERROR_MSG_FORMAT, \
+    ORG_DETAILS_UPDATE_ALERT, ORG_OEF_UPDATE_ALERT
 
 
 def get_global_alert_messages(request):
@@ -30,9 +31,7 @@ def get_global_alert_messages(request):
         if request.user.is_authenticated() and not request.user.is_active and '/activate/' not in request.path:
             alert_messages.append({
                 "type": ACTIVATION_ALERT_TYPE,
-                "alert": ACTIVATION_ERROR,
-                "link":  ACTIVATION_RESEND_LINK,
-                "banner_id": ACTIVATION_BANNER_ID
+                "alert": ACTIVATION_ERROR_MSG_FORMAT.format(reverse('resend_activation_email'))
             })
 
     if '/oef/dashboard' in request.path:

--- a/lms/djangoapps/philu_overrides/context_processor.py
+++ b/lms/djangoapps/philu_overrides/context_processor.py
@@ -31,7 +31,7 @@ def get_global_alert_messages(request):
         if request.user.is_authenticated() and not request.user.is_active and '/activate/' not in request.path:
             alert_messages.append({
                 "type": ACTIVATION_ALERT_TYPE,
-                "alert": ACTIVATION_ERROR_MSG_FORMAT.format(reverse('resend_activation_email'))
+                "alert": ACTIVATION_ERROR_MSG_FORMAT.format(reverse('resend_activation_email'), request.user.id)
             })
 
     if '/oef/dashboard' in request.path:

--- a/lms/djangoapps/philu_overrides/context_processor.py
+++ b/lms/djangoapps/philu_overrides/context_processor.py
@@ -4,7 +4,7 @@ from lms.djangoapps.onboarding.helpers import get_org_metric_update_prompt, \
     is_org_detail_prompt_available, is_org_detail_platform_overlay_available, \
     get_org_oef_update_prompt, is_org_oef_prompt_available
 from lms.djangoapps.philu_overrides.constants import ACTIVATION_ERROR, ACTIVATION_ALERT_TYPE, \
-    ORG_DETAILS_UPDATE_ALERT, ORG_OEF_UPDATE_ALERT
+    ACTIVATION_RESEND_LINK, ORG_DETAILS_UPDATE_ALERT, ORG_OEF_UPDATE_ALERT, ACTIVATION_BANNER_ID
 
 
 def get_global_alert_messages(request):
@@ -30,7 +30,9 @@ def get_global_alert_messages(request):
         if request.user.is_authenticated() and not request.user.is_active and '/activate/' not in request.path:
             alert_messages.append({
                 "type": ACTIVATION_ALERT_TYPE,
-                "alert": ACTIVATION_ERROR
+                "alert": ACTIVATION_ERROR,
+                "link":  ACTIVATION_RESEND_LINK,
+                "banner_id": ACTIVATION_BANNER_ID
             })
 
     if '/oef/dashboard' in request.path:


### PR DESCRIPTION
**Problem**: Add "Resend Activation Email" button to site banner

**Solution**:

1. **`views.py`**: Added a view named `resend_activation_email` which takes in the request, checks if the user has already been activated (to contain any abuse of the endpoint), and if the user has not been activated, resends the activation email using the pre-existing `reactivation_email_for_user_custom` method from `philu_overrides.helpers`. At the end it sends back an appropriate response to the AJAX call from the front-end.

2. **`urls.py`**: Imported the `resend_activation_email` view and assigned it to a new url pattern: `{lms}/philu/api/resend_activation_email/`.

3. **`context_processor.py`**: Updated the `get_global_alert_messages` method in case of an activation email banner using the constants defined in `constants.py` to pass along the activation-banner-id and `activation-link` HTML to `header.html`. 

4. **`constants.py`**: Defined the new constants to specify activation email link:
- `ACTIVATION_BANNER_ID`: Required by the front-end JS to update text of the HTML element after successfully re-sending the activation email
- `ACTIVATION_LINK_ID`: Used by the `ACTIVATION_RESEND_LINK` constant, there to specify the API endpoint
- `ACTIVATION_RESEND_LINK`: HTML anchor tag upon which the event listener listens.

**Problem**: Resend activation email button was enabled on LMS side, but had to be separately enabled in NodeBB

**Resolution**: 

1. **`views.py`**: `csrf_exempt` decorator was used since the django requires that the token is sent in request headers. The request from NodeBB falls under CORS request and hence, that requests is forbidden at edX side. Also, the `user_id` is now being sent in body of the request from both the sides. 

2. **`constants.py`**: `user id` is being sent as a data attribute to edX side to be sent in AJAX request body.

3.  **`context_processor.py`**: `user id` inserted in the alert format-able string to be used by AJAX request