### PR TITLE
LP-1637 G2A RegFlow: User Registration Implementation

### DIFF
--- a/openedx/features/partners/g2a/constants.py
+++ b/openedx/features/partners/g2a/constants.py
@@ -1,0 +1,16 @@
+ORGANIZATION_NAME='organization_name'
+ENGLISH_PROFICIENCY='english_proficiency'
+START_MONTH_YEAR='start_month_year'
+IS_INTERESTS_DATA_SUBMITTED='is_interests_data_submitted'
+FIRST_NAME='first_name'
+LAST_NAME='last_name'
+GIVE2ASIA_DEFAULT_DATA = {
+    'year_of_birth': 2000,
+    'level_of_education': 'IWRNS',
+    ENGLISH_PROFICIENCY: 'IWRNS',
+    START_MONTH_YEAR: '11/2019',
+    IS_INTERESTS_DATA_SUBMITTED: True,
+    ORGANIZATION_NAME: None,
+    FIRST_NAME: None,
+    LAST_NAME: None,
+}

--- a/openedx/features/partners/g2a/forms.py
+++ b/openedx/features/partners/g2a/forms.py
@@ -130,3 +130,7 @@ class Give2AsiaAccountCreationForm(forms.Form):
                     .format(email=email)
             )
         return email
+
+    def clean_registration_data(self, registration_data):
+        """Once form is validated, call this function to get clean registration data"""
+        registration_data.update(self.cleaned_data)

--- a/openedx/features/partners/g2a/forms.py
+++ b/openedx/features/partners/g2a/forms.py
@@ -3,6 +3,7 @@ from django import forms
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
+from lms.djangoapps.onboarding.models import Organization
 from openedx.core.djangoapps.user_api import accounts as accounts_settings
 from openedx.core.djangoapps.user_api.accounts.api import check_account_exists
 from student import forms as student_forms
@@ -14,6 +15,7 @@ class UsernameField(student_forms.UsernameField):
     """
     Inheriting UsernameField from student app. Parent class is not validating username already exists
     """
+
     def clean(self, value):
         clean_username = super(UsernameField, self).clean(value)
 
@@ -70,6 +72,19 @@ class Give2AsiaAccountCreationForm(forms.Form):
             "min_length": _NAME_TOO_SHORT_MSG,
         },
         validators=[validate_name]
+    )
+
+    def validate_organization_name(organization_name):
+        """ Check if organization associated to partner exists"""
+        organization = Organization.objects.filter(label__iexact=organization_name).first()
+        if organization is None:
+            raise forms.ValidationError("Organization associated to this partner is not found")
+
+    organization_name = forms.CharField(
+        error_messages={
+            "required": "Valid organization name associated to this partner is required",
+        },
+        validators=[validate_organization_name]
     )
 
     def __init__(

--- a/openedx/features/partners/g2a/forms.py
+++ b/openedx/features/partners/g2a/forms.py
@@ -1,0 +1,117 @@
+import re
+from django import forms
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.core.exceptions import ValidationError
+from openedx.core.djangoapps.user_api import accounts as accounts_settings
+from openedx.core.djangoapps.user_api.accounts.api import check_account_exists
+from student import forms as student_forms
+from student.models import CourseEnrollmentAllowed, email_exists_or_retired
+from util.password_policy_validators import validate_password
+
+
+class UsernameField(student_forms.UsernameField):
+    """
+    Inheriting UsernameField from student app. Parent class is not validating username already exists
+    """
+    def clean(self, value):
+        clean_username = super(UsernameField, self).clean(value)
+
+        # check if user name is not already taken
+        conflicts = check_account_exists(username=clean_username)
+        if conflicts and 'username' in conflicts:
+            raise forms.ValidationError(
+                "The username you entered is already being used. Please enter another username.")
+
+        return clean_username
+
+
+class Give2AsiaAccountCreationForm(forms.Form):
+    """
+    A form to validate account creation data for Give2Asia. It is currently only used for
+    validation, not rendering.
+    """
+
+    _NAME_MIN_LENGTH = 3
+    _EMAIL_INVALID_MSG = "A properly formatted e-mail is required"
+    _NAME_TOO_SHORT_MSG = "Your legal name must be a minimum of three characters long"
+
+    username = UsernameField()
+
+    email = forms.EmailField(
+        max_length=accounts_settings.EMAIL_MAX_LENGTH,
+        min_length=accounts_settings.EMAIL_MIN_LENGTH,
+        error_messages={
+            "required": _EMAIL_INVALID_MSG,
+            "invalid": _EMAIL_INVALID_MSG,
+            "max_length": "Email cannot be more than %(limit_value)s characters long",
+        }
+    )
+
+    password = forms.CharField()
+
+    def validate_name(name):
+        """
+        Verifies a Full_Name is valid, raises a ValidationError otherwise.
+        Args:
+            name (unicode): The name to validate.
+        """
+        if student_forms.contains_html(name):
+            raise forms.ValidationError('Full Name cannot contain the following characters: < >')
+
+        name_split = name.strip().split(" ", 1)
+        if len(name_split) < 2:
+            raise forms.ValidationError("Full Name must include first name and last name")
+
+    name = forms.CharField(
+        min_length=_NAME_MIN_LENGTH,
+        error_messages={
+            "required": _NAME_TOO_SHORT_MSG,
+            "min_length": _NAME_TOO_SHORT_MSG,
+        },
+        validators=[validate_name]
+    )
+
+    def __init__(
+        self,
+        data=None,
+        tos_required=True
+    ):
+        super(Give2AsiaAccountCreationForm, self).__init__(data)
+
+        if tos_required:
+            self.fields["terms_of_service"] = student_forms.TrueField(
+                error_messages={"required": "You must accept the terms of service."}
+            )
+
+    def clean_password(self):
+        """Enforce password policies (if applicable)"""
+        password = self.cleaned_data["password"]
+        # Creating a temporary user object to test password against username
+        # This user should NOT be saved
+        username = self.cleaned_data.get('username')
+        email = self.cleaned_data.get('email')
+        temp_user = User(username=username, email=email) if username else None
+        validate_password(password, temp_user)
+        return password
+
+    def clean_email(self):
+        """ Enforce email restrictions (if applicable) """
+        email = self.cleaned_data["email"]
+        if settings.REGISTRATION_EMAIL_PATTERNS_ALLOWED is not None:
+            # This Open edX instance has restrictions on what email addresses are allowed.
+            allowed_patterns = settings.REGISTRATION_EMAIL_PATTERNS_ALLOWED
+            # We append a '$' to the regexs to prevent the common mistake of using a
+            # pattern like '.*@edx\\.org' which would match 'bob@edx.org.badguy.com'
+            if not any(re.match(pattern + "$", email) for pattern in allowed_patterns):
+                # This email is not on the whitelist of allowed emails. Check if
+                # they may have been manually invited by an instructor and if not,
+                # reject the registration.
+                if not CourseEnrollmentAllowed.objects.filter(email=email).exists():
+                    raise ValidationError("Unauthorized email address.")
+        if email_exists_or_retired(email):
+            raise ValidationError(
+                "It looks like {email} belongs to an existing account. Try again with a different email address."
+                    .format(email=email)
+            )
+        return email

--- a/openedx/features/partners/g2a/views.py
+++ b/openedx/features/partners/g2a/views.py
@@ -18,6 +18,7 @@ from lms.djangoapps.onboarding.models import (
 )
 from lms.djangoapps.onboarding.models import RegistrationType
 from lms.djangoapps.philu_overrides.user_api.views import RegistrationViewCustom
+from nodebb.helpers import update_nodebb_for_user_status
 from notification_prefs.views import enable_notifications
 from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
@@ -74,7 +75,7 @@ class Give2AsiaRegistrationView(RegistrationViewCustom):
         except Exception:
             error_message = {"Error": {"reason": "User registration failed"}}
             log.exception(error_message)
-            return JsonResponse({"Error": {"reason": "User registration failed"}}, status=400)
+            return JsonResponse(error_message, status=400)
 
         RegistrationType.objects.create(choice=1, user=request.user)
         response = JsonResponse({"success": True})
@@ -200,6 +201,10 @@ def create_account_with_params_custom(request, params):
                 }
             }
         )
+
+    # Since all required data corresponding to new user is saved in relevant models
+    # request NodeBB to activate registered user
+    update_nodebb_for_user_status(params['username'])
 
     # Announce registration
     REGISTER_USER.send(sender=None, user=user, registration=registration)

--- a/openedx/features/partners/g2a/views.py
+++ b/openedx/features/partners/g2a/views.py
@@ -1,9 +1,239 @@
+import analytics
+import datetime
+import json
+import logging
+from django.conf import settings
+from django.contrib.auth import authenticate, login
+from django.contrib.auth.models import User
+from django.core.exceptions import ObjectDoesNotExist
+from django.core.validators import ValidationError
+from django.db import transaction
+from django.utils.translation import get_language
 from edxmako.shortcuts import render_to_response
-
+from eventtracking import tracker
+from lms.djangoapps.onboarding.models import (
+    EmailPreference,
+    Organization,
+    UserExtendedProfile
+)
+from lms.djangoapps.onboarding.models import RegistrationType
+from lms.djangoapps.philu_overrides.helpers import save_user_partner_network_consent
+from lms.djangoapps.philu_overrides.user_api.views import RegistrationViewCustom
+from notification_prefs.views import enable_notifications
+from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+from openedx.core.djangoapps.user_api.preferences import api as preferences_api
+from openedx.core.djangoapps.user_authn.cookies import set_logged_in_cookies
+from openedx.core.djangoapps.user_authn.views.register import REGISTER_USER, \
+    record_registration_attributions
 from openedx.features.partners.helpers import get_partner_recommended_courses
+from pytz import UTC
+from student.models import Registration, create_comments_service_user, UserProfile
+from util.json_request import JsonResponse
+
+from .forms import Give2AsiaAccountCreationForm
+
+log = logging.getLogger("edx.student")
+AUDIT_LOG = logging.getLogger("audit")
 
 
 def g2a_dashboard(request):
     # TODO: The argument must be dynamic after integration of LP-1632
     courses = get_partner_recommended_courses('give2asia')
     return render_to_response('partners/g2a/dashboard.html', {'recommended_courses': courses})
+
+
+class Give2AsiaRegistrationView(RegistrationViewCustom):
+    """
+    This class handles registration flow for give2asia users. It inherit some basic functionality from original (normal)
+    registration flow
+    """
+
+    def get(self, request):
+        pass
+
+    def post(self, request):
+
+        registration_data = request.POST.copy()
+
+        # Adding basic dummy data, required to bypass onboarding flow
+        registration_data['organization_name'] = 'Give2Asia'
+        registration_data['year_of_birth'] = 2000
+        registration_data['level_of_education'] = 'IWRNS'
+        registration_data['partners_opt_in'] = ''
+
+        # validate data provided by end user
+        account_creation_form = Give2AsiaAccountCreationForm(data=registration_data, tos_required=True)
+        if not account_creation_form.is_valid():
+            return JsonResponse({"Error": dict(account_creation_form.errors.items())}, status=400)
+
+        registration_data['email'] = account_creation_form.cleaned_data["email"]
+        registration_data['username'] = account_creation_form.cleaned_data["username"]
+        registration_data['password'] = account_creation_form.cleaned_data["password"]
+        name = account_creation_form.cleaned_data["name"]
+        registration_data['name'] = name
+
+        name_split = name.split(" ", 1)
+        registration_data['first_name'] = name_split[0]
+        registration_data['last_name'] = name_split[1]
+
+        try:
+            # Create models for user, UserProfile and UserExtendedProfile
+            user = create_account_with_params_custom(request, registration_data)
+            self.save_user_utm_info(user)
+            save_user_partner_network_consent(user, registration_data['partners_opt_in'])
+        except Exception:
+            return JsonResponse({"Error": {"reason": "User registration failed"}}, status=400)
+
+        RegistrationType.objects.create(choice=1, user=request.user)
+        response = JsonResponse({"success": True})
+        set_logged_in_cookies(request, response, user)
+        return response
+
+
+def create_account_with_params_custom(request, params):
+    # Copy params so we can modify it; we can't just do dict(params) because if
+    # params is request.POST, that results in a dict containing lists of values
+    params = dict(params.items())
+
+    extended_profile_fields = configuration_helpers.get_value('extended_profile_fields', [])
+
+    # Perform operations within a transaction that are critical to account creation
+    with transaction.atomic():
+        try:
+            # Create user and activate it
+            user = User(
+                username=params['username'],
+                email=params["email"],
+                first_name=params['first_name'],
+                last_name=params['last_name'],
+                is_active=True,
+            )
+            user.set_password(params["password"])
+            registration = Registration()
+
+            user.save()
+            registration.register(user)
+        except Exception:  # pylint: disable=broad-except
+            log.exception("User creation failed for user {username}.".format(username=params['username']))
+            raise
+
+        try:
+            # Update User profile
+
+            profile_fields = [
+                "name", "level_of_education", "gender", "country", "year_of_birth"
+            ]
+            profile = UserProfile(
+                user=user,
+                **{key: params.get(key) for key in profile_fields}
+            )
+
+            # Return a dictionary containing the extended_profile_fields and values
+            extended_profile_data = {
+                key: value
+                for key, value in params.items() if key in extended_profile_fields and value is not None
+            }
+
+            if extended_profile_data:
+                profile.meta = json.dumps(extended_profile_data)
+            profile.save()
+        except Exception:  # pylint: disable=broad-except
+            log.exception("UserProfile creation failed for user {id}.".format(id=user.id))
+            raise
+
+        try:
+            # create User Extended Profile
+            extended_profile = UserExtendedProfile.objects.create(user=user)
+            extended_profile.english_proficiency = 'IWRNS'
+            extended_profile.start_month_year = '11/2019'
+            extended_profile.is_interests_data_submitted = True
+
+            # Assign Give2Asia organization to new user
+            organization_to_assign = Organization.objects.filter(label__iexact=params['organization_name']).first()
+            if organization_to_assign is None:
+                log.exception("Cannot associate user to organization {org}, it does not exist".format(
+                    org=params['organization_name']))
+                raise ObjectDoesNotExist()
+            extended_profile.organization = organization_to_assign
+            extended_profile.save()
+        except Exception:  # pylint: disable=broad-except
+            log.exception("User extended profile creation failed for user {id}.".format(id=user.id))
+            raise ValidationError()
+
+        try:
+            user_email_preferences, created = EmailPreference.objects.get_or_create(user=user)
+            user_email_preferences.opt_in = False
+            user_email_preferences.save()
+        except Exception:  # pylint: disable=broad-except
+            log.exception("User email preferences creation failed for user {id}.".format(id=user.id))
+            raise ValidationError()
+
+    # Perform operations that are non-critical parts of account creation
+    preferences_api.set_user_preference(user, LANGUAGE_KEY, get_language())
+
+    if settings.FEATURES.get('ENABLE_DISCUSSION_EMAIL_DIGEST'):
+        try:
+            enable_notifications(user)
+        except Exception:  # pylint: disable=broad-except
+            log.exception("Enable discussion notifications failed for user {id}.".format(id=user.id))
+
+    # Track the user's registration
+    if hasattr(settings, 'LMS_SEGMENT_KEY') and settings.LMS_SEGMENT_KEY:
+        tracking_context = tracker.get_tracker().resolve_context()
+        identity_args = [
+            user.id,  # pylint: disable=no-member
+            {
+                'email': user.email,
+                'username': user.username,
+                'name': profile.name,
+                # Mailchimp requires the age & yearOfBirth to be integers, we send a sane integer default if falsey.
+                'age': profile.age or -1,
+                'yearOfBirth': profile.year_of_birth or datetime.datetime.now(UTC).year,
+                'education': profile.level_of_education_display,
+                'address': profile.mailing_address,
+                'gender': profile.gender_display,
+                'country': unicode(profile.country),
+            }
+        ]
+        analytics.identify(*identity_args)
+        analytics.track(
+            user.id,
+            "edx.bi.user.account.registered",
+            {
+                'category': 'conversion',
+                'label': params.get('course_id'),
+                'provider': None
+            },
+            context={
+                'ip': tracking_context.get('ip'),
+                'Google Analytics': {
+                    'clientId': tracking_context.get('client_id')
+                }
+            }
+        )
+
+    # Announce registration
+    REGISTER_USER.send(sender=None, user=user, registration=registration)
+
+    create_comments_service_user(user)
+
+    registration.activate()
+
+    # login user immediately after a user creates an account,
+    new_user = authenticate(username=user.username, password=params['password'])
+    login(request, new_user)
+    request.session.set_expiry(0)
+
+    try:
+        record_registration_attributions(request, new_user)
+    # Don't prevent a user from registering due to attribution errors.
+    except Exception:  # pylint: disable=broad-except
+        log.exception('Error while attributing cookies to user registration.')
+
+    # TODO: there is no error checking here to see that the user actually logged in successfully,
+    # and is not yet an active user.
+    if new_user is not None:
+        AUDIT_LOG.info(u"Login success on new account creation - {0}".format(new_user.username))
+
+    return new_user

--- a/openedx/features/partners/urls.py
+++ b/openedx/features/partners/urls.py
@@ -3,8 +3,9 @@ The urls for philu features app.
 """
 from django.conf.urls import url
 
-from .views import dashboard
+from .views import dashboard, register_user
 
 urlpatterns = [
     url(r"^partner/(?P<slug>[0-9a-z]+)/$",  dashboard, name="partner_url"),
+    url(r'^partner/(?P<slug>[0-9a-z]+)/register/$', register_user, name="partner_register"),
 ]

--- a/openedx/features/partners/views.py
+++ b/openedx/features/partners/views.py
@@ -1,5 +1,10 @@
 from django.shortcuts import get_object_or_404
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.debug import sensitive_post_parameters
+from django.views.decorators.http import require_http_methods
+
 from g2a.views import g2a_dashboard
+from .g2a.views import Give2AsiaRegistrationView
 from .models import Partner
 
 
@@ -9,3 +14,18 @@ def dashboard(request, slug):
     if partner.slug == 'give2asia':
         return g2a_dashboard(request)
 
+
+@require_http_methods(["POST"])
+@sensitive_post_parameters('password')
+@csrf_exempt
+def register_user(request, slug):
+    """
+    This is general registering view, for users of all partners
+    :param request: The Django request.
+    :param slug: partner slug
+    :return: JsonResponse object with success/error message
+    """
+    partner = get_object_or_404(Partner, slug=slug)
+    # TODO: we need to make it generic for all partners
+    if partner.slug == 'give2asia':
+        return Give2AsiaRegistrationView.as_view()(request)

--- a/openedx/features/partners/views.py
+++ b/openedx/features/partners/views.py
@@ -28,4 +28,4 @@ def register_user(request, slug):
     partner = get_object_or_404(Partner, slug=slug)
     # TODO: we need to make it generic for all partners
     if partner.slug == 'give2asia':
-        return Give2AsiaRegistrationView.as_view()(request)
+        return Give2AsiaRegistrationView.as_view()(request, partner=partner)


### PR DESCRIPTION
## [LP-1637](https://philanthropyu.atlassian.net/browse/LP-1637)

- Implement Registration for new users (Full name, email, password)
- Populate other mandatory (yet hidden) fields automatically
- Auto-activate these users (if it only requires active flag to be set as true)
- Associate these users with the “Give2Asia” organization
- Create a bridge table between user and partner table

**Steps to test code:**
1. Create partner in Django admin
2. Make one user (on platform) admin of that partner (organization), in this case Give2Asia
3. Partner label in Django admin must match exactly to organization name in platform
4. Register new user through partner's registration API