### PR TITLE
[LP-1630] Fixed case of circular dependency between VisibleBlocks and PersistentSubsectionGrade

### DIFF
--- a/lms/djangoapps/grades/models.py
+++ b/lms/djangoapps/grades/models.py
@@ -233,11 +233,7 @@ class VisibleBlocks(models.Model):
         Returns a dictionary mapping hashes of these block records to the
         block record objects.
         """
-        grades_with_blocks = PersistentSubsectionGrade.objects.select_related('visible_blocks').filter(
-            user_id=user_id,
-            course_id=course_key,
-        )
-        prefetched = {grade.visible_blocks.hashed: grade.visible_blocks for grade in grades_with_blocks}
+        prefetched = {record.hashed: record for record in cls.objects.filter(course_id=course_key)}
         get_cache(cls._CACHE_NAMESPACE)[cls._cache_key(user_id, course_key)] = prefetched
         return prefetched
 


### PR DESCRIPTION
The underlying exception was occurring:
```
Traceback (most recent call last):
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/views/index.py", line 153, in get
    return self.render(request)
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/views/index.py", line 217, in render
    return render_to_response('courseware/courseware.html', self._create_courseware_context(request))
  File "/edx/app/edxapp/edx-platform/common/djangoapps/edxmako/shortcuts.py", line 169, in render_to_response
    return HttpResponse(render_to_string(template_name, dictionary, namespace, request), **kwargs)
  File "/edx/app/edxapp/edx-platform/common/djangoapps/edxmako/shortcuts.py", line 159, in render_to_string
    return template.render(dictionary, request)
  File "/edx/app/edxapp/edx-platform/common/djangoapps/edxmako/template.py", line 59, in render
    return self.mako_template.render_unicode(**context_dictionary)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/mako/template.py", line 454, in render_unicode
    as_unicode=True)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/newrelic/hooks/template_mako.py", line 25, in __call__
    return self.__wrapped(template, *args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/mako/runtime.py", line 829, in _render
    **_kwargs_for_callable(callable_, data))
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/mako/runtime.py", line 864, in _render_context
    _exec_template(inherit, lclcontext, args=args, kwargs=kwargs)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/mako/runtime.py", line 890, in _exec_template
    callable_(context, *args, **kwargs)
  File "/tmp/mako_lms/a600aa18afc5d8cc46540449ff2323c5/philu/lms/templates/main.html.py", line 373, in render_body
    __M_writer(filters.decode.utf8(self.body()))
  File "/tmp/mako_lms/a600aa18afc5d8cc46540449ff2323c5/philu/lms/templates/courseware/courseware.html.py", line 117, in render_body
    runtime._include_file(context, u'/courseware/course_navigation.html', _template_uri, progress=progress, table_of_contents=toc, active_tab=active_tab, active_page='courseware')
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/mako/runtime.py", line 752, in _include_file
    callable_(ctx, **_kwargs_for_include(callable_, context._data, **kwargs))
  File "/tmp/mako_lms/a600aa18afc5d8cc46540449ff2323c5/philu/lms/templates/courseware/course_navigation.html.py", line 83, in render_body
    progress = get_all_course_progress(request.user, course)
  File "/edx/app/edxapp/edx-platform/common/djangoapps/nodebb/helpers.py", line 41, in get_all_course_progress
    course_grade = CourseGradeFactory().read(student, course)
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/grades/course_grade_factory.py", line 51, in read
    return self._update(user, course_data)
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/grades/course_grade_factory.py", line 182, in _update
    course_grade._subsection_grade_factory.bulk_create_unsaved()
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/grades/subsection_grade_factory.py", line 62, in bulk_create_unsaved
    self.student, self._unsaved_subsection_grades.values(), self.course_data.course_key
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/grades/subsection_grade.py", line 290, in bulk_create_models
    return PersistentSubsectionGrade.bulk_create_grades(params, student.id, course_key)
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/grades/models.py", line 450, in bulk_create_grades
    user_id, course_key, [params['visible_blocks'] for params in grade_params_iter]
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/grades/models.py", line 227, in bulk_get_or_create
    cls.bulk_create(user_id, course_key, non_existent_brls)
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/grades/models.py", line 213, in bulk_create
    for brl in block_record_lists
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/query.py", line 443, in bulk_create
    ids = self._batched_insert(objs_without_pk, fields, batch_size)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/query.py", line 1102, in _batched_insert
    self._insert(item, fields=fields, using=self.db)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/query.py", line 1079, in _insert
    return query.get_compiler(using=using).execute_sql(return_id)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/sql/compiler.py", line 1112, in execute_sql
    cursor.execute(sql, params)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/backends/utils.py", line 64, in execute
    return self.cursor.execute(sql, params)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/utils.py", line 94, in __exit__
    six.reraise(dj_exc_type, dj_exc_value, traceback)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/backends/utils.py", line 64, in execute
    return self.cursor.execute(sql, params)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/backends/mysql/base.py", line 101, in execute
    return self.cursor.execute(query, args)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/newrelic/hooks/database_dbapi2.py", line 25, in execute
    *args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/MySQLdb/cursors.py", line 205, in execute
    self.errorhandler(self, exc, value)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/MySQLdb/connections.py", line 36, in defaulterrorhandler
    raise errorclass, errorvalue
IntegrityError: (1062, "Duplicate entry 's0GG/YJjdNCqRqZo2OVPQWL8UHc=' for key 'hashed'")
```
The circular dependency is in the following code and the case arises when PersistentSubsectionGrade (s) are/is missing for a user in a course:

```
@classmethod
    def bulk_create_grades(cls, grade_params_iter, user_id, course_key):
        """
        Bulk creation of grades.
        """
        if not grade_params_iter:
            return

        PersistentSubsectionGradeOverride.prefetch(user_id, course_key)

        map(cls._prepare_params, grade_params_iter)
        VisibleBlocks.bulk_get_or_create(
            user_id, course_key, [params['visible_blocks'] for params in grade_params_iter]
        )
        map(cls._prepare_params_visible_blocks_id, grade_params_iter)

        grades = [PersistentSubsectionGrade(**params) for params in grade_params_iter]
        grades = cls.objects.bulk_create(grades)
        for grade in grades:
            cls._emit_grade_calculated_event(grade)
        return grades
```
As in the code above you can see PersistentSubsectionGrade(s) are created after VisibleBlocks. For the code where VisibleBlocks is created, it filters out VisibleBlocks that already exist. To fetch the relevant VisibleBlocks it was using the query:
```
PersistentSubsectionGrade.objects.select_related('visible_blocks').filter(
            user_id=user_id,
            course_id=course_key,
        )
```
