### PR TITLE
LP-1674 OTHER Send emails to prompt learners to view & download

### DIFF
--- a/common/djangoapps/philu_commands/management/commands/auto_generate_certificates_for_open_courses.py
+++ b/common/djangoapps/philu_commands/management/commands/auto_generate_certificates_for_open_courses.py
@@ -33,7 +33,7 @@ def is_course_valid_for_certificate_auto_generation(course):
     return bool(course.has_started() and not course.has_ended() and course.may_certify())
 
 
-def is_eligible_for_certificate(user_course_enrollment,
+def _is_eligible_for_certificate(user_course_enrollment,
                                 course_chapters, user):
     """
     This is checking if the user enrollment if eligible for the certificate generation.
@@ -80,7 +80,7 @@ class Command(BaseCommand):
                     qualifiers={'category': 'course'}
                 )
 
-                if is_eligible_for_certificate(user_course_enrollment, course_chapters, user):
+                if _is_eligible_for_certificate(user_course_enrollment, course_chapters, user):
                     continue
 
                 # generate_user_certificates will add a request to xqueue to generate a new certificate for the user.

--- a/common/djangoapps/philu_commands/management/commands/auto_generate_certificates_for_open_courses.py
+++ b/common/djangoapps/philu_commands/management/commands/auto_generate_certificates_for_open_courses.py
@@ -46,7 +46,7 @@ def is_eligible_for_certificate(user_course_enrollment,
     COURSE_STRUCTURE_INDEX = 0
     ESTIMATED_MODULE_COMPLETION_DAYS = 7
     today = datetime.now(UTC)
-    delta_days = (today - user_course_enrollment.created.date()).days
+    delta_days = (today.date() - user_course_enrollment.created.date()).days
     total_modules = len(course_chapters[COURSE_STRUCTURE_INDEX].children)
     last_module_id = str(course_chapters[COURSE_STRUCTURE_INDEX].children[-1])
     usage_key = UsageKey.from_string(last_module_id)


### PR DESCRIPTION
[FIX] TypeError: unsupported operand type(s) for -: 'datetime.datetime' and 'datetime.date'