### PR TITLE
LP-1707 Handling badging edge cases for team

### DIFF
--- a/common/djangoapps/nodebb/signals/handlers.py
+++ b/common/djangoapps/nodebb/signals/handlers.py
@@ -20,6 +20,7 @@ from nodebb.models import DiscussionCommunity, TeamGroupChat
 from nodebb.helpers import get_community_id
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.signals.signals import COURSE_CERT_AWARDED
+from openedx.features.badging.models import UserBadge
 
 from student.models import ENROLL_STATUS_CHANGE, EnrollStatusChange, UserProfile, CourseEnrollment
 from xmodule.modulestore.django import modulestore
@@ -367,6 +368,7 @@ def join_team_subcategory_on_nodebb(sender, instance, created, **kwargs):
                 )
             )
         else:
+            UserBadge.assign_missing_team_badges(instance.user.id, instance.team.id)
             log.info('Success: User has joined team subcategory %s successfully' %
                      instance.team.name)
 

--- a/openedx/features/badging/constants.py
+++ b/openedx/features/badging/constants.py
@@ -1,13 +1,21 @@
 CONVERSATIONALIST = ('conversationalist', 'Conversationalist')
 TEAM_PLAYER = ('team', 'Team player')
 
+BADGE_ID_KEY = 'badge_id'
 BADGES_KEY = 'badges'
+COURSE_ID_KEY = 'course_id'
+COMMUNITY_ID_KEY = 'community_id'
+ROOM_ID_KEY = 'room_id'
+TEAM_ID_KEY = 'team_id'
+TEAM_ROOM_ID_KEY = 'team__room_id'
+THRESHOLD_KEY = 'badge__threshold'
+
+BADGE_ROOT_URL = '{root_url}/courses/{course_id}'
+
 BADGE_NOT_FOUND_ERROR = 'There exists no badge with id {badge_id}'
 BADGE_TYPE_ERROR = 'Cannot assign badge {badge_id} of unknown type {badge_type}'
-BADGE_ROOT_URL = '{root_url}/courses/{course_id}'
 FILTER_BADGES_ERROR = 'Unable to get badges for team {team_id}'
 INVALID_COMMUNITY_ERROR = 'Cannot assign badge {badge_id} for invalid community {community_id}'
 INVALID_TEAM_ERROR = 'Cannot assign badge {badge_id} for invalid team {community_id}'
-TEAM_ID_KEY = 'team_id'
-TEAM_ROOM_ID_KEY = 'team__room_id'
+TEAM_BADGE_ERROR = 'Cannot assign missing badges to user {user_id} in team {team_id}'
 UNKNOWN_COURSE_ERROR = 'Cannot assign badge {badge_id} for team {community_id} in unknown course'

--- a/openedx/features/badging/constants.py
+++ b/openedx/features/badging/constants.py
@@ -4,7 +4,6 @@ TEAM_PLAYER = ('team', 'Team player')
 BADGE_ID_KEY = 'badge_id'
 BADGES_KEY = 'badges'
 COURSE_ID_KEY = 'course_id'
-COMMUNITY_ID_KEY = 'community_id'
 ROOM_ID_KEY = 'room_id'
 TEAM_ID_KEY = 'team_id'
 TEAM_ROOM_ID_KEY = 'team__room_id'

--- a/openedx/features/badging/models.py
+++ b/openedx/features/badging/models.py
@@ -2,14 +2,10 @@ import logging
 
 from django.contrib.auth.models import User
 from django.db import models
-
 from rest_framework.renderers import JSONRenderer
 
-from lms.djangoapps.teams.models import CourseTeamMembership, CourseTeam
-from nodebb.constants import (
-    TEAM_PLAYER_ENTRY_INDEX,
-    CONVERSATIONALIST_ENTRY_INDEX
-)
+from lms.djangoapps.teams.models import CourseTeamMembership
+from nodebb.constants import CONVERSATIONALIST_ENTRY_INDEX, TEAM_PLAYER_ENTRY_INDEX
 from nodebb.helpers import get_course_id_by_community_id
 from nodebb.models import TeamGroupChat
 from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
@@ -31,6 +27,9 @@ class Badge(models.Model):
     type = models.CharField(max_length=100, blank=False, null=False, choices=BADGE_TYPES)
     image = models.CharField(max_length=255, blank=False, null=False)
     date_created = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        app_label = 'badging'
 
     def __unicode__(self):
         return self.name
@@ -73,6 +72,7 @@ class UserBadge(models.Model):
     date_earned = models.DateTimeField(auto_now=True)
 
     class Meta:
+        app_label = 'badging'
         unique_together = ('user', 'badge', 'course_id', 'community_id')
 
     def __unicode__(self):
@@ -145,3 +145,28 @@ class UserBadge(models.Model):
             error = badge_constants.BADGE_TYPE_ERROR.format(badge_id=badge_id, badge_type=badge_type)
             log.exception(error)
             raise Exception(error)
+
+    @classmethod
+    def assign_missing_team_badges(cls, user_id, team_id):
+        """
+        Assign all previous (missing) badges when user joins a team,
+        such that he has same number of badges as any other member
+        of same team
+        """
+        if user_id is None or team_id is None:
+            error = badge_constants.TEAM_BADGE_ERROR.format(user_id=user_id, team_id=team_id)
+            log.exception(error)
+            return Exception(error)
+
+        team_group_chat = TeamGroupChat.objects.filter(team_id=team_id).values(badge_constants.ROOM_ID_KEY).first()
+        earned_team_badges = UserBadge.objects.filter(community_id=team_group_chat[badge_constants.ROOM_ID_KEY]).values(
+            badge_constants.BADGE_ID_KEY, badge_constants.COURSE_ID_KEY, badge_constants.COMMUNITY_ID_KEY,
+            badge_constants.THRESHOLD_KEY).distinct()
+        # assign team's earned badges to current user which are not already earned
+        for user_badge in earned_team_badges:
+            UserBadge.objects.get_or_create(
+                user_id=user_id,
+                badge_id=user_badge[badge_constants.BADGE_ID_KEY],
+                course_id=user_badge[badge_constants.COURSE_ID_KEY],
+                community_id=user_badge[badge_constants.COMMUNITY_ID_KEY]
+            )


### PR DESCRIPTION
### Description

[LP-1707](https://philanthropyu.atlassian.net/browse/LP-1707)

Handle badge assignment edge cases in course team

### Notes

Second part of AC does not need dev work. When user un-enroll from course, his record in `CourseTeamMembership` remains intact hence he can get team badges
