### PR TITLE
LP-1707 Handling badging edge cases for team

### DIFF
--- a/common/djangoapps/nodebb/signals/handlers.py
+++ b/common/djangoapps/nodebb/signals/handlers.py
@@ -20,6 +20,7 @@ from nodebb.models import DiscussionCommunity, TeamGroupChat
 from nodebb.helpers import get_community_id
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.signals.signals import COURSE_CERT_AWARDED
+from openedx.features.badging.models import UserBadge
 
 from student.models import ENROLL_STATUS_CHANGE, EnrollStatusChange, UserProfile, CourseEnrollment
 from xmodule.modulestore.django import modulestore
@@ -367,6 +368,7 @@ def join_team_subcategory_on_nodebb(sender, instance, created, **kwargs):
                 )
             )
         else:
+            UserBadge.assign_missing_team_badges(instance.user.id, instance.team.id)
             log.info('Success: User has joined team subcategory %s successfully' %
                      instance.team.name)
 

--- a/openedx/features/badging/constants.py
+++ b/openedx/features/badging/constants.py
@@ -1,13 +1,20 @@
 CONVERSATIONALIST = ('conversationalist', 'Conversationalist')
 TEAM_PLAYER = ('team', 'Team player')
 
+BADGE_ID_KEY = 'badge_id'
 BADGES_KEY = 'badges'
+COURSE_ID_KEY = 'course_id'
+ROOM_ID_KEY = 'room_id'
+TEAM_ID_KEY = 'team_id'
+TEAM_ROOM_ID_KEY = 'team__room_id'
+THRESHOLD_KEY = 'badge__threshold'
+
+BADGE_ROOT_URL = '{root_url}/courses/{course_id}'
+
 BADGE_NOT_FOUND_ERROR = 'There exists no badge with id {badge_id}'
 BADGE_TYPE_ERROR = 'Cannot assign badge {badge_id} of unknown type {badge_type}'
-BADGE_ROOT_URL = '{root_url}/courses/{course_id}'
 FILTER_BADGES_ERROR = 'Unable to get badges for team {team_id}'
 INVALID_COMMUNITY_ERROR = 'Cannot assign badge {badge_id} for invalid community {community_id}'
 INVALID_TEAM_ERROR = 'Cannot assign badge {badge_id} for invalid team {community_id}'
-TEAM_ID_KEY = 'team_id'
-TEAM_ROOM_ID_KEY = 'team__room_id'
+TEAM_BADGE_ERROR = 'Cannot assign missing badges to user {user_id} in team {team_id}'
 UNKNOWN_COURSE_ERROR = 'Cannot assign badge {badge_id} for team {community_id} in unknown course'


### PR DESCRIPTION
### Description

[LP-1707](https://philanthropyu.atlassian.net/browse/LP-1707)

Handle badge assignment edge cases in course team

### Notes

Second part of AC does not need dev work. When user un-enroll from course, his record in `CourseTeamMembership` remains intact hence he can get team badges
