### PR TITLE
LP-2014 Fix other field max length and error message

### DIFF
--- a/openedx/custom/forms/fields.py
+++ b/openedx/custom/forms/fields.py
@@ -20,10 +20,12 @@ class MultiSelectWithOtherFormField(MultiSelectFormField):
 
         self.other_max_length = other_max_length
         self.error_messages.update(
-            dict(invalid_length=_('Other field value. %(value)s maximum allowed length violation.')))
+            dict(invalid_length=_(
+                'Other field value, maximum allowed length violation. Allowed limit is upto {other_max_length} characters.').format(
+                other_max_length=other_max_length)))
 
     def valid_value(self, value):
-        return len(value) < self.other_max_length
+        return len(value) <= self.other_max_length
 
     def validate(self, value):
         """


### PR DESCRIPTION
### Description

[LP-2014](https://philanthropyu.atlassian.net/browse/LP-2014)

"Other" field in all the questions is not accepting 50 characters. It is accepting less than 50 characters.

Improper validation message is displaying if the maximum allowed length is violated for Other field.