### PR TITLE
LP-1868 Create proxy url for CloudSponge configuration

### DIFF
--- a/lms/urls.py
+++ b/lms/urls.py
@@ -7,6 +7,7 @@ from django.conf.urls import include, url
 from django.conf.urls.static import static
 from django.contrib.admin import autodiscover as django_autodiscover
 from django.utils.translation import ugettext_lazy as _
+from django.views.generic import TemplateView
 from django.views.generic.base import RedirectView
 from rest_framework_swagger.views import get_swagger_view
 
@@ -96,6 +97,10 @@ urlpatterns = [
     url(r'', include('openedx.features.specializations.urls')),
     url(r'^marketplace/', include('openedx.features.marketplace.urls')),
     url(r'^idea/', include('openedx.features.idea.urls')),
+
+    # CloudSponge proxy url to lets the OAuth providers know, we are asking CloudSponge for address book
+    url(r'^auth/proxy/cloudsponge/$', TemplateView.as_view(template_name='features/smart_referral/auth_proxy.html'),
+        name='cloud_sponge_proxy'),
 
     # Event tracking endpoints
     url(r'', include('track.urls')),


### PR DESCRIPTION
### Description

[LP-1868](https://philanthropyu.atlassian.net/browse/LP-1868) Configuration of CloudSponge with our platform

[philu-edx-theme PR](https://github.com/philanthropy-u/philu-edx-theme/pull/1244)

Add a description of your changes here.

### Notes

In order to configure provider apps with CloudSponge we need to create a static page that can act as a proxy URL. This proxy URL will be added to the configuration of all providers i.e. Google, Microsoft, and Yahoo.

The proxy URL will be `{base_url}/auth/proxy/cloudsponge`

