### PR TITLE
[POSTFIX] LP-2066: Update the `save_user_utm` method and tests for not checking against UTMs

### DIFF
--- a/openedx/features/user_leads/helpers.py
+++ b/openedx/features/user_leads/helpers.py
@@ -20,4 +20,7 @@ def save_user_utm(request):
     utm_params = get_utm_params(request)
 
     if not user.is_anonymous():
-        UserLeads.objects.get_or_create(user=user, origin=origin, **utm_params)
+        try:
+            UserLeads.objects.get(user=user, origin=origin)
+        except UserLeads.DoesNotExist:
+            UserLeads.objects.create(user=user, origin=origin, **utm_params)


### PR DESCRIPTION
### Description

[LP-2066](https://philanthropyu.atlassian.net/browse/LP-2066)

Earlier we were using `get_or_create` method to save a UTM if it did not already exist. But it was breaking because we were passing it `utm_params` in parameters which do not work because only `user` and `origin` are defined as `unique_together` in the model. Passing it `utm_params` does not return the existing entry, which causes an `IntegrityError`.