### PR TITLE
LP-2030: Fix partners broken unit tests for views

### DIFF
--- a/openedx/features/partners/tests/test_views.py
+++ b/openedx/features/partners/tests/test_views.py
@@ -5,15 +5,15 @@ from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
 
 from lms.djangoapps.onboarding.models import Organization, UserExtendedProfile
-from openedx.core.djangolib.testing.philu_utils import configure_philu_theme
 from openedx.core.lib.api.test_utils import ApiTestCase
 from openedx.features.partners.constants import PARTNER_USER_STATUS_WAITING
 from openedx.features.partners.models import PartnerUser
 from openedx.features.partners.tests.factories import FocusAreaFactory, OrganizationFactory, PartnerFactory
+from openedx.features.philu_utils.tests.mixins import PhiluThemeMixin
 
 
 @ddt
-class PartnerRegistrationViewTest(ApiTestCase):
+class PartnerRegistrationViewTest(PhiluThemeMixin, ApiTestCase):
     """
     Includes test cases for partner registration
     """
@@ -32,11 +32,6 @@ class PartnerRegistrationViewTest(ApiTestCase):
                                              label=self.ORGANIZATION)
         self.registration_url = reverse('partner_register', args=[self.PARTNER])
         self.partner_url = reverse('partner_url', args=[self.PARTNER])
-
-    @classmethod
-    def setUpClass(cls):
-        super(PartnerRegistrationViewTest, cls).setUpClass()
-        configure_philu_theme()
 
     def test_create_new_partner_landing_page_is_accessible(self):
         """

--- a/openedx/features/partners/tests/test_views.py
+++ b/openedx/features/partners/tests/test_views.py
@@ -5,6 +5,7 @@ from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
 
 from lms.djangoapps.onboarding.models import Organization, UserExtendedProfile
+from openedx.core.djangolib.testing.philu_utils import configure_philu_theme
 from openedx.core.lib.api.test_utils import ApiTestCase
 from openedx.features.partners.constants import PARTNER_USER_STATUS_WAITING
 from openedx.features.partners.models import PartnerUser
@@ -18,7 +19,7 @@ class PartnerRegistrationViewTest(ApiTestCase):
     """
 
     NAME = 'bob23 james'
-    COUNTRY = 'Pakistan'
+    COUNTRY = 'PK'
     ORGANIZATION = 'arbisoft'
     EMAIL = 'bob@example.com'
     USERNAME = 'bob123'
@@ -31,6 +32,11 @@ class PartnerRegistrationViewTest(ApiTestCase):
                                              label=self.ORGANIZATION)
         self.registration_url = reverse('partner_register', args=[self.PARTNER])
         self.partner_url = reverse('partner_url', args=[self.PARTNER])
+
+    @classmethod
+    def setUpClass(cls):
+        super(PartnerRegistrationViewTest, cls).setUpClass()
+        configure_philu_theme()
 
     def test_create_new_partner_landing_page_is_accessible(self):
         """


### PR DESCRIPTION
### Description

[LP-2030](https://philanthropyu.atlassian.net/browse/LP-2030)

There were a few unit tests broken for views in the partners app. 

1. One test was failing because the theme was not set and template was not found. Used the helper `configure_philu_theme` recently introduced to fix that.

2. Other unit tests were failing because of a recent change in the partner registration form, where the country drop down was changed to send the country key instead of the country value. Changed the country value used in unit tests to country key, and those started working.