### PR TITLE
LP-2031: Fix philu_courseware broken unit tests.

### DIFF
--- a/openedx/features/philu_courseware/tests/test_competency_assessment_recording.py
+++ b/openedx/features/philu_courseware/tests/test_competency_assessment_recording.py
@@ -18,8 +18,9 @@ class CompetencyAssessmentRecordTest(APITestCase):
     def setUp(self):
         self.user = UserFactory()
         self.client.force_authenticate(self.user)
-        self.end_point = reverse('record_competency_assessment')
+        self.end_point = reverse('record_and_fetch_competency_assessment')
         self.valid_record = {
+            'chapter_id': 'test-chapter',
             'problem_id': 'block-v1:PUCIT+IT1+1+type@problem+block@7f1593ef300e4f569e26356b65d3b76b',
             'problem_text': 'This is a problem',
             'assessment_type': 'pre',


### PR DESCRIPTION
### Description

[LP-2031](https://philanthropyu.atlassian.net/browse/LP-2031)

Test were failing because the view which had to be called was being fetched by `reverse` and the name of the URL being passed to reverse was not correct. After fixing that, one test was still failing in serializer when the view was called. This was because one mandatory model field `chapter_id` was not being passed in the data from the test.