### PR TITLE
LP-2114 Fixing mailchimp broken unit tests

### DIFF
--- a/common/djangoapps/mailchimp_pipeline/tests/helpers.py
+++ b/common/djangoapps/mailchimp_pipeline/tests/helpers.py
@@ -17,8 +17,7 @@ def create_organization(user):
     organization = OrganizationFactory(
         admin=user,
         alternate_admin_email=user.email,
-        label='test_org',
-        org_type='test_org_type'
+        label='test_org'
     )
     organization.save()
     return organization

--- a/common/djangoapps/mailchimp_pipeline/tests/test_signals.py
+++ b/common/djangoapps/mailchimp_pipeline/tests/test_signals.py
@@ -152,4 +152,6 @@ class MailchimpPipelineSignalTestClass(TestCase):
         """
         organization = create_organization(self.user)
         org_label, org_type, work_area = get_org_data_for_mandrill(organization)
-        mocked_delay.assert_called_with(org_label, org_type, work_area, settings.MAILCHIMP_LEARNERS_LIST_ID)
+        mocked_delay.assert_called_with(
+            org_label, org_type, work_area, organization.id, settings.MAILCHIMP_LEARNERS_LIST_ID
+        )

--- a/lms/djangoapps/onboarding/tests/factories.py
+++ b/lms/djangoapps/onboarding/tests/factories.py
@@ -53,3 +53,4 @@ class OrganizationFactory(DjangoModelFactory):
         django_get_or_create = ('label', )
 
     label = factory.Sequence(u'Organization{0}'.format)
+    org_type = factory.Faker('pystr', max_chars=10)


### PR DESCRIPTION
### Description

[LP-2114](https://philanthropyu.atlassian.net/browse/LP-2114) Fixing Mailchimp broken unit tests

### Notes

1. There were two issue with tests
	- Task `update_org_details_at_mailchimp` have now 4 param, and in unit test it was not updated, so it was taking only 3 params
	- The max length of organization's `org_type` is up to 10 characters, but for unit test data `org_type` was provided of more than 10 characters long
2. All 27 test in `djangoapps/mailchimp_pipeline` passed
