### PR TITLE
Mabdullahz/lp 2095

### DIFF
--- a/cms/static/js/index.js
+++ b/cms/static/js/index.js
@@ -61,8 +61,9 @@ define(['domReady', 'jquery', 'underscore', 'js/utils/cancel_on_escape', 'js/vie
 
             analytics.track('Created a Course', course_info);
             CreateCourseUtils.create(course_info, function(errorMessage) {
+                var msg = edx.HtmlUtils.joinHtml(edx.HtmlUtils.HTML('<p>'), errorMessage, edx.HtmlUtils.HTML('</p>'));
                 $('.create-course .wrap-error').addClass('is-shown');
-                $('#course_creation_error').html('<p>' + errorMessage + '</p>');
+                edx.HtmlUtils.setHtml($('#course_creation_error'), msg);
                 $('.new-course-save').addClass('is-disabled').attr('aria-disabled', true);
             });
         };
@@ -136,8 +137,9 @@ define(['domReady', 'jquery', 'underscore', 'js/utils/cancel_on_escape', 'js/vie
 
             analytics.track('Created a Library', lib_info);
             CreateLibraryUtils.create(lib_info, function(errorMessage) {
+                var msg = edx.HtmlUtils.joinHtml(edx.HtmlUtils.HTML('<p>'), errorMessage, edx.HtmlUtils.HTML('</p>'));
                 $('.create-library .wrap-error').addClass('is-shown');
-                $('#library_creation_error').html('<p>' + errorMessage + '</p>');
+                edx.HtmlUtils.setHtml($('#library_creation_error'), msg);
                 $('.new-library-save').addClass('is-disabled').attr('aria-disabled', true);
             });
         };

--- a/cms/static/js/models/uploads.js
+++ b/cms/static/js/models/uploads.js
@@ -14,7 +14,7 @@ define(['backbone', 'underscore', 'gettext'], function(Backbone, _, gettext) {
         validate: function(attrs, options) {
             if (attrs.selectedFile && !this.checkTypeValidity(attrs.selectedFile)) {
                 return {
-                    message: _.template(gettext('Only <%= fileTypes %> files can be uploaded. Please select a file ending in <%= fileExtensions %> to upload.'))(  // eslint-disable-line max-len
+                    message: _.template(gettext('Only <%- fileTypes %> files can be uploaded. Please select a file ending in <%- (fileExtensions) %> to upload.'))(  // eslint-disable-line max-len
                     this.formatValidTypes()
                 ),
                     attributes: {selectedFile: true}
@@ -62,7 +62,7 @@ define(['backbone', 'underscore', 'gettext'], function(Backbone, _, gettext) {
             }
             var or = gettext('or');
             var formatTypes = function(types) {
-                return _.template('<%= initial %> <%= or %> <%= last %>')({
+                return _.template('<%- initial %> <%- or %> <%- last %>')({
                     initial: _.initial(types).join(', '),
                     or: or,
                     last: _.last(types)

--- a/cms/static/js/views/edit_chapter.js
+++ b/cms/static/js/views/edit_chapter.js
@@ -59,8 +59,8 @@ define(['underscore', 'jquery', 'gettext', 'edx-ui-toolkit/js/utils/html-utils',
                     asset_path: this.$('input.chapter-asset-path').val()
                 });
                 var msg = new FileUploadModel({
-                    title: _.template(gettext('Upload a new PDF to “<%= name %>”'))(
-                        {name: course.escape('name')}),
+                    title: _.template(gettext('Upload a new PDF to “<%- name %>”'))(
+                        {name: course.get('name')}),
                     message: gettext('Please select a PDF file to upload.'),
                     mimeTypes: ['application/pdf']
                 });


### PR DESCRIPTION
### Description

[LP-2095](https://philanthropyu.atlassian.net/browse/LP-2095)

Applied the security [patch1](https://discuss.openedx.org/t/security-patch-for-xss-issue/2061) and [patch2](discuss.openedx.org/t/security-patch-for-edit-chapter-xss-lint-issues/2030) for xss issue. Please visit the security patch link for more details on why this was required.

### Details
1. **Changes made by the patch**: 

  - Use of `edx.HtmlUtils.HTML` when displaying the error in a `<p>` tag to avoid the execution of any malicious script trying to execute. This change has been made in two places inside the `cms/static/js/index.js` file, in `CreateCourseUtils.create` and `CreateLibraryUtils.create` methods.
  - Use of backbone `<%-` tag which escapes any HTML from the given value instead of `<%=` in `cms/static/js/models/uploads.js`

2. **Ripples in our custom code**: This JS change does not seem to have any ripples in our custom code, since we have not changed anything related to Files and Uploads page.

3. **Broken Unit Tests**: This JS change will not break any unit tests.
