### PR TITLE
LP-2161 Add revert user post assessment attempts API

### DIFF
--- a/openedx/features/philu_courseware/helpers.py
+++ b/openedx/features/philu_courseware/helpers.py
@@ -131,14 +131,19 @@ def validate_problem_id(problem_id):
     validate if problem_id is valid UsageKeyField or not
     """
     if not problem_id:
-        raise serializers.ValidationError(_('Problem id is required'))
+        raise serializers.ValidationError({'problem_id': _('Problem id is required')})
     try:
         return UsageKey.from_string(problem_id)
     except InvalidKeyError:
-        raise serializers.ValidationError(constants.INVALID_PROBLEM_ID_MSG)
+        raise serializers.ValidationError({'problem_id': constants.INVALID_PROBLEM_ID_MSG})
 
 
 def revert_user_attempts_from_edx(course_id, user, problem_usage_key):
+    """
+    :param course_id: str course id of user
+    :param user: Django User
+    :param problem_usage_key: UsageKey problem id
+    """
     course_id = CourseKey.from_string(course_id)
     module_state_key = problem_usage_key.map_into_course(course_id)
     try:

--- a/openedx/features/philu_courseware/helpers.py
+++ b/openedx/features/philu_courseware/helpers.py
@@ -3,18 +3,18 @@ from logging import getLogger
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
-from rest_framework.exceptions import APIException
+from opaque_keys import InvalidKeyError
+from opaque_keys.edx.django.models import CourseKey, UsageKey
 from rest_framework import serializers
-
+from rest_framework.exceptions import APIException
+from submissions.api import SubmissionError
 
 from courseware.models import StudentModule
 from lms.djangoapps.instructor import enrollment
-from opaque_keys import InvalidKeyError
-from opaque_keys.edx.django.models import CourseKey, UsageKey
-from submissions.api import SubmissionError
 from xmodule.modulestore.django import modulestore
-from .models import CompetencyAssessmentRecord
+
 from . import constants
+from .models import CompetencyAssessmentRecord
 
 log = getLogger(__name__)
 

--- a/openedx/features/philu_courseware/models.py
+++ b/openedx/features/philu_courseware/models.py
@@ -1,7 +1,6 @@
 from django.contrib.auth.models import User
 from django.db import models
 from model_utils.models import TimeStampedModel
-
 from opaque_keys.edx.django.models import UsageKeyField
 
 from .constants import COMPETENCY_ASSESSMENT_TYPE_CHOICES, CORRECTNESS_CHOICES

--- a/openedx/features/philu_courseware/models.py
+++ b/openedx/features/philu_courseware/models.py
@@ -1,10 +1,18 @@
+from django.contrib.auth.models import User
 from django.db import models
 from model_utils.models import TimeStampedModel
-from django.contrib.auth.models import User
 
 from opaque_keys.edx.django.models import UsageKeyField
 
 from .constants import COMPETENCY_ASSESSMENT_TYPE_CHOICES, CORRECTNESS_CHOICES
+
+
+class CompetencyAssessmentManager(models.Manager):
+    def revert_user_post_assessment_attempts(self, user, problem_id):
+        post_assessment_records = self.get_queryset().filter(problem_id=problem_id, user=user, assessment_type='post')
+        delete_result = post_assessment_records.delete()
+        deleted_records_count = delete_result[0]
+        return deleted_records_count
 
 
 class CompetencyAssessmentRecord(TimeStampedModel):
@@ -15,12 +23,14 @@ class CompetencyAssessmentRecord(TimeStampedModel):
 
     attempt = models.IntegerField()
     correctness = models.CharField(max_length=9, choices=CORRECTNESS_CHOICES)
-    # comma separated choice ids for example choice_1,choice_2,choice_3
+    # It stores comma separated choice ids for example choice_1,choice_2,choice_3
     choice_id = models.CharField(max_length=255)
     choice_text = models.TextField()
     score = models.FloatField()
     user = models.ForeignKey(User, db_index=True, on_delete=models.CASCADE)
     question_number = models.IntegerField(default=None, blank=True, null=True)
+
+    objects = CompetencyAssessmentManager()
 
     def __unicode__(self):
         return '{problem}, question({question_number}), {username}, {assessment_type}, attempt({attempt})'.format(

--- a/openedx/features/philu_courseware/serializers.py
+++ b/openedx/features/philu_courseware/serializers.py
@@ -1,9 +1,6 @@
 from rest_framework import serializers
 
-from opaque_keys import InvalidKeyError
-from opaque_keys.edx.django.models import UsageKey
-
-from .constants import INVALID_PROBLEM_ID_MSG
+from .helpers import validate_problem_id
 from .models import CompetencyAssessmentRecord
 
 
@@ -14,10 +11,7 @@ class CompetencyAssessmentRecordSerializer(serializers.ModelSerializer):
         """
         validate if problem_id is valid UsageKeyField or not
         """
-        try:
-            return UsageKey.from_string(problem_id)
-        except InvalidKeyError:
-            raise serializers.ValidationError(INVALID_PROBLEM_ID_MSG)
+        return validate_problem_id(problem_id)
 
     class Meta:
         model = CompetencyAssessmentRecord

--- a/openedx/features/philu_courseware/tests/factories.py
+++ b/openedx/features/philu_courseware/tests/factories.py
@@ -1,0 +1,22 @@
+import factory
+
+from opaque_keys.edx.keys import UsageKey
+from openedx.features.philu_courseware.models import CompetencyAssessmentRecord
+from student.tests.factories import UserFactory
+
+
+class CompetencyAssessmentRecordFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = CompetencyAssessmentRecord
+
+    chapter_id = 'test-chapter'
+    problem_id = UsageKey.from_string('block-v1:PUCIT+IT1+1+type@problem+block@7f1593ef300e4f569e26356b65d3b76b')
+    problem_text = 'Test problem text'
+    assessment_type = 'post'
+    attempt = 1
+    correctness = 'correct'
+    choice_id = '1'
+    choice_text = 'This is test choice'
+    score = '1'
+    user = factory.SubFactory(UserFactory)
+    question_number = 1

--- a/openedx/features/philu_courseware/tests/factories.py
+++ b/openedx/features/philu_courseware/tests/factories.py
@@ -1,6 +1,6 @@
 import factory
-
 from opaque_keys.edx.keys import UsageKey
+
 from openedx.features.philu_courseware.models import CompetencyAssessmentRecord
 from student.tests.factories import UserFactory
 

--- a/openedx/features/philu_courseware/tests/test_competency_assessment_record_manager.py
+++ b/openedx/features/philu_courseware/tests/test_competency_assessment_record_manager.py
@@ -1,8 +1,9 @@
 from django.test import TestCase
-
 from opaque_keys.edx.keys import UsageKey
+
 from openedx.features.philu_courseware.models import CompetencyAssessmentRecord
 from student.tests.factories import UserFactory
+
 from .factories import CompetencyAssessmentRecordFactory
 
 

--- a/openedx/features/philu_courseware/tests/test_competency_assessment_record_manager.py
+++ b/openedx/features/philu_courseware/tests/test_competency_assessment_record_manager.py
@@ -1,0 +1,45 @@
+from django.test import TestCase
+
+from opaque_keys.edx.keys import UsageKey
+from openedx.features.philu_courseware.models import CompetencyAssessmentRecord
+from student.tests.factories import UserFactory
+from .factories import CompetencyAssessmentRecordFactory
+
+
+class CompetencyAssessmentRecordManagerTestCase(TestCase):
+
+    def setup_attempts(self, assessment_type='post'):
+        for question_number in range(5):
+            CompetencyAssessmentRecordFactory(
+                user=self.user,
+                assessment_type=assessment_type,
+                question_number=question_number + 1
+            )
+
+    def delete_post_assessment_attempts(self):
+        return CompetencyAssessmentRecord.objects.revert_user_post_assessment_attempts(
+            user=self.user, problem_id=self.problem_id
+        )
+
+    def setUp(self):
+        self.user = UserFactory()
+        self.problem_id = UsageKey.from_string(
+            'block-v1:PUCIT+IT1+1+type@problem+block@7f1593ef300e4f569e26356b65d3b76b'
+        )
+
+    def test_revert_post_assessment_attempts_with_zero_attempts(self):
+        """Test revert post assessment attempts method when user has not attempted any assessment"""
+        deleted_attempts_count = self.delete_post_assessment_attempts()
+        self.assertEqual(deleted_attempts_count, 0)
+
+    def test_revert_post_assessment_attempts_with_pre_assessment_attempted(self):
+        """Test revert post assessment attempts method when user has attempted only pre assessment"""
+        self.setup_attempts('pre')
+        deleted_attempts_count = self.delete_post_assessment_attempts()
+        self.assertEqual(deleted_attempts_count, 0)
+
+    def test_revert_post_assessment_attempts_with_post_assessment_attempted(self):
+        """Test revert post assessment attempts method when user has attempted post assessment"""
+        self.setup_attempts()
+        deleted_attempts_count = self.delete_post_assessment_attempts()
+        self.assertEqual(deleted_attempts_count, 5)

--- a/openedx/features/philu_courseware/tests/test_competency_assessment_record_manager.py
+++ b/openedx/features/philu_courseware/tests/test_competency_assessment_record_manager.py
@@ -18,15 +18,13 @@ class CompetencyAssessmentRecordManagerTestCase(TestCase):
             )
 
     def delete_post_assessment_attempts(self):
+        problem_id = UsageKey.from_string('block-v1:PUCIT+IT1+1+type@problem+block@7f1593ef300e4f569e26356b65d3b76b')
         return CompetencyAssessmentRecord.objects.revert_user_post_assessment_attempts(
-            user=self.user, problem_id=self.problem_id
+            user=self.user, problem_id=problem_id
         )
 
     def setUp(self):
         self.user = UserFactory()
-        self.problem_id = UsageKey.from_string(
-            'block-v1:PUCIT+IT1+1+type@problem+block@7f1593ef300e4f569e26356b65d3b76b'
-        )
 
     def test_revert_post_assessment_attempts_with_zero_attempts(self):
         """Test revert post assessment attempts method when user has not attempted any assessment"""

--- a/openedx/features/philu_courseware/tests/test_helpers.py
+++ b/openedx/features/philu_courseware/tests/test_helpers.py
@@ -1,0 +1,24 @@
+from django.test import TestCase
+from rest_framework.exceptions import ValidationError
+
+from openedx.features.philu_courseware.helpers import validate_problem_id
+
+
+class ValidateProblemIdTestCase(TestCase):
+
+    def test_empty_problem_id(self):
+        """Test empty problem id"""
+        with self.assertRaises(ValidationError):
+            validate_problem_id('')
+
+    def test_invalid_problem_id(self):
+        """Test invalid problem id"""
+        with self.assertRaises(ValidationError):
+            validate_problem_id('invalid-problem-id')
+
+    def test_valid_problem_id(self):
+        """Test valid problem id"""
+        try:
+            validate_problem_id('block-v1:PUCIT+IT1+1+type@problem+block@7f1593ef300e4f569e26356b65d3b76b')
+        except ValidationError:
+            self.fail('Validation error raised for a valid problem id')

--- a/openedx/features/philu_courseware/urls.py
+++ b/openedx/features/philu_courseware/urls.py
@@ -12,6 +12,7 @@ urlpatterns = [
         competency_assessments_score_view, name='competency_assessments_score'),
     url(r'^api/record_and_fetch_competency_assessment/(?P<chapter_id>[a-z0-9]+)/$',
         record_and_fetch_competency_assessment, name='record_and_fetch_competency_assessment'),
-    url(r'^api/courses/{}/courseware/revert_user_post_assessment_attempts/$'.format(settings.COURSE_ID_PATTERN),
-        revert_user_post_assessment_attempts, name='revert_user_post_assessment_attempts')
+    url(r'^api/courses/{course_id}/courseware/revert_user_post_assessment_attempts/$'.format(
+        course_id=settings.COURSE_ID_PATTERN), revert_user_post_assessment_attempts,
+        name='revert_user_post_assessment_attempts')
 ]

--- a/openedx/features/philu_courseware/urls.py
+++ b/openedx/features/philu_courseware/urls.py
@@ -4,9 +4,8 @@ from django.conf.urls import url
 from .views import (
     competency_assessments_score_view,
     record_and_fetch_competency_assessment,
-    revert_user_post_assessment_attempts,
+    revert_user_post_assessment_attempts
 )
-
 
 urlpatterns = [
     url(r'^api/courses/courseware/(?P<chapter_id>[^/]*)/competency_assessments_score/$',

--- a/openedx/features/philu_courseware/urls.py
+++ b/openedx/features/philu_courseware/urls.py
@@ -1,11 +1,18 @@
 from django.conf import settings
 from django.conf.urls import url
 
-from .views import competency_assessments_score_view, record_and_fetch_competency_assessment
+from .views import (
+    competency_assessments_score_view,
+    record_and_fetch_competency_assessment,
+    revert_user_post_assessment_attempts,
+)
 
 
 urlpatterns = [
     url(r'^api/courses/courseware/(?P<chapter_id>[^/]*)/competency_assessments_score/$',
         competency_assessments_score_view, name='competency_assessments_score'),
-    url(r'^api/record_and_fetch_competency_assessment/(?P<chapter_id>[a-z0-9]+)/$', record_and_fetch_competency_assessment, name='record_and_fetch_competency_assessment')
+    url(r'^api/record_and_fetch_competency_assessment/(?P<chapter_id>[a-z0-9]+)/$',
+        record_and_fetch_competency_assessment, name='record_and_fetch_competency_assessment'),
+    url(r'^api/courses/{}/courseware/revert_user_post_assessment_attempts/$'.format(settings.COURSE_ID_PATTERN),
+        revert_user_post_assessment_attempts, name='revert_user_post_assessment_attempts')
 ]

--- a/openedx/features/philu_courseware/views.py
+++ b/openedx/features/philu_courseware/views.py
@@ -8,6 +8,7 @@ from rest_framework import status
 from rest_framework.decorators import api_view, renderer_classes
 from rest_framework.response import Response
 from rest_framework.renderers import JSONRenderer, BrowsableAPIRenderer
+from rest_framework.serializers import ValidationError
 
 from openedx.core.lib.api.view_utils import view_auth_classes
 
@@ -15,7 +16,8 @@ from lms.djangoapps.courseware.exceptions import CourseAccessRedirect
 from lms.djangoapps.courseware.courseware_access_exception import CoursewareAccessException
 
 from .constants import COMP_ASSESS_RECORD_SUCCESS_MSG
-from .helpers import get_competency_assessments_score
+from .helpers import get_competency_assessments_score, revert_user_attempts_from_edx, validate_problem_id
+from .models import CompetencyAssessmentRecord
 from .serializers import CompetencyAssessmentRecordSerializer
 
 
@@ -65,3 +67,23 @@ def record_and_fetch_competency_assessment(request, chapter_id):
             }, status=status.HTTP_201_CREATED)
     else:
         return Response({'message': serializer.errors}, status=status.HTTP_400_BAD_REQUEST)
+
+
+@api_view(['POST'])
+@view_auth_classes(is_authenticated=True)
+@renderer_classes([JSONRenderer, BrowsableAPIRenderer])
+def revert_user_post_assessment_attempts(request, course_id):
+    user = request.user
+    problem_id = request.data.get('problem_id')
+    validated_problem_id = validate_problem_id(problem_id)
+    reverted_attempts_count = CompetencyAssessmentRecord.objects.revert_user_post_assessment_attempts(
+                                problem_id=validated_problem_id, user=user)
+    has_deleted_post_assessment_attempts = reverted_attempts_count > 0
+    if has_deleted_post_assessment_attempts:
+        revert_user_attempts_from_edx(course_id, user, validated_problem_id)
+        success_response = {
+            'message': _('Your attempts has been reverted successfully')
+        }
+        return Response(success_response, status=status.HTTP_200_OK)
+    else:
+        raise ValidationError(_('This user has no attempts for this problem id in post assessment'))

--- a/openedx/features/philu_courseware/views.py
+++ b/openedx/features/philu_courseware/views.py
@@ -7,7 +7,6 @@ from rest_framework import status
 from rest_framework.decorators import api_view, renderer_classes
 from rest_framework.renderers import BrowsableAPIRenderer, JSONRenderer
 from rest_framework.response import Response
-from rest_framework.serializers import ValidationError
 
 from lms.djangoapps.courseware.courseware_access_exception import CoursewareAccessException
 from lms.djangoapps.courseware.exceptions import CourseAccessRedirect
@@ -75,13 +74,10 @@ def revert_user_post_assessment_attempts(request, course_id):
     problem_id = request.data.get('problem_id')
     validated_problem_id = validate_problem_id(problem_id)
     reverted_attempts_count = CompetencyAssessmentRecord.objects.revert_user_post_assessment_attempts(
-                                problem_id=validated_problem_id, user=user)
+        problem_id=validated_problem_id, user=user
+    )
     has_deleted_post_assessment_attempts = reverted_attempts_count > 0
     if has_deleted_post_assessment_attempts:
         revert_user_attempts_from_edx(course_id, user, validated_problem_id)
-        success_response = {
-            'message': _('Your attempts has been reverted successfully')
-        }
-        return Response(success_response, status=status.HTTP_200_OK)
-    else:
-        raise ValidationError(_('This user has no attempts for this problem id in post assessment'))
+
+    return Response(status=status.HTTP_200_OK)

--- a/openedx/features/philu_courseware/views.py
+++ b/openedx/features/philu_courseware/views.py
@@ -3,17 +3,15 @@ Views to add features in courseware.
 """
 
 from django.utils.translation import ugettext as _
-
 from rest_framework import status
 from rest_framework.decorators import api_view, renderer_classes
+from rest_framework.renderers import BrowsableAPIRenderer, JSONRenderer
 from rest_framework.response import Response
-from rest_framework.renderers import JSONRenderer, BrowsableAPIRenderer
 from rest_framework.serializers import ValidationError
 
-from openedx.core.lib.api.view_utils import view_auth_classes
-
-from lms.djangoapps.courseware.exceptions import CourseAccessRedirect
 from lms.djangoapps.courseware.courseware_access_exception import CoursewareAccessException
+from lms.djangoapps.courseware.exceptions import CourseAccessRedirect
+from openedx.core.lib.api.view_utils import view_auth_classes
 
 from .constants import COMP_ASSESS_RECORD_SUCCESS_MSG
 from .helpers import get_competency_assessments_score, revert_user_attempts_from_edx, validate_problem_id


### PR DESCRIPTION
### Description

[LP-2161](https://philanthropyu.atlassian.net/browse/LP-2161)

### How to Test?

- First you need to setup a competency assessment. 
- Attempt post assessment.
- Hit following endpoint with required data to revert post assessment attempts.

```
{base_url}/api/courses/{course_id}/courseware/revert_user_post_assessment_attempts/
```

This is POST api which needs following data
```
{
    "problem_id": "block-v1:Arbisoft+CA101+2020_CA+type@problem+block@23c2935e351da7e00fbd"
}
```