### PR TITLE
LP-2180 Unit test for custom settings app

### DIFF
--- a/common/djangoapps/custom_settings/models.py
+++ b/common/djangoapps/custom_settings/models.py
@@ -18,6 +18,9 @@ class CustomSettings(models.Model):
     seo_tags = models.TextField(null=True, blank=True)
     course_open_date = models.DateTimeField(null=True)
 
+    class Meta:
+        app_label = 'custom_settings'
+
     def __unicode__(self):
         return '{} | {}'.format(self.id, self.is_featured)
 

--- a/common/djangoapps/custom_settings/signals/handlers.py
+++ b/common/djangoapps/custom_settings/signals/handlers.py
@@ -15,7 +15,7 @@ def initialize_course_settings(sender, instance, created, **kwargs):
     """
     When ever a new course is created
     1: We add a default entry for the given course in the CustomSettings Model
-    2: We add a an honor mode for the given course so students can view certificates on their dashboard and progress page
+    2: We add an honor mode for the given course so students can view certificates on their dashboard and progress page
     """
 
     if created:

--- a/common/djangoapps/custom_settings/tests/factories.py
+++ b/common/djangoapps/custom_settings/tests/factories.py
@@ -1,0 +1,20 @@
+import factory
+from factory.django import DjangoModelFactory
+from faker.providers import internet
+
+from custom_settings.models import CustomSettings
+from openedx.features.philu_utils.model_factory import random_course_key
+
+factory.Faker.add_provider(internet)
+
+
+class CustomSettingsFactory(DjangoModelFactory):
+    class Meta(object):
+        model = CustomSettings
+        django_get_or_create = ('course_short_id',)
+
+    id = factory.LazyFunction(random_course_key)
+    tags = factory.Faker('word')
+    course_short_id = factory.Faker('random_int')
+    seo_tags = '{"title":"test", "description":"test"}'
+    course_open_date = factory.Faker('date_time')

--- a/common/djangoapps/custom_settings/tests/test_handlers.py
+++ b/common/djangoapps/custom_settings/tests/test_handlers.py
@@ -1,0 +1,22 @@
+import pytest
+
+from course_modes.models import CourseMode
+from custom_settings.models import CustomSettings
+from custom_settings.signals.handlers import initialize_course_settings
+from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
+from openedx.features.philu_utils.py_test import does_not_raise
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('created', [False, True])
+def test_get_course_open_date_from_settings(created):
+    """Assert that CustomSettings and CourseMode objects are created when handler is called"""
+    course_overview = CourseOverviewFactory(display_name='test_overview')
+
+    with does_not_raise():
+        initialize_course_settings(None, course_overview, created)
+
+        if created:
+            assert CustomSettings.objects.filter(id=course_overview.id).count() == 1
+            assert CourseMode.objects.filter(course_id=course_overview.id, mode_slug='honor',
+                                             mode_display_name='test_overview').count() == 1

--- a/common/djangoapps/custom_settings/tests/test_helpers.py
+++ b/common/djangoapps/custom_settings/tests/test_helpers.py
@@ -1,0 +1,57 @@
+from datetime import datetime
+
+import pytest
+from mock import Mock
+from pytz import UTC
+
+from custom_settings.helpers import get_course_open_date_from_settings, validate_course_open_date
+from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
+
+
+@pytest.mark.parametrize(
+    'course_open_date, expected',
+    [('', ''), (None, ''), (datetime(2020, 12, 17), '12/17/2020')],
+    ids=['course_open_date_empty', 'course_open_date_None', 'course_open_date_valid']
+)
+def test_get_course_open_date_from_settings(course_open_date, expected):
+    """Assert that course_open_date is in proper date format"""
+    settings = Mock(spec=['settings'], course_open_date=course_open_date)
+    assert get_course_open_date_from_settings(settings) == expected
+
+
+@pytest.mark.django_db
+@pytest.fixture()
+def course_open_date_settings_fixture():
+    """A fixture to create CourseOverview test data and return mocked settings object with CourseOverview id"""
+    course_start_date = datetime(2020, 1, 1, tzinfo=UTC)
+    course_end_date = datetime(2021, 1, 1, tzinfo=UTC)
+    course_overview = CourseOverviewFactory(start=course_start_date, end=course_end_date)
+    return Mock(spec=['settings'], id=course_overview.id)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    'course_open_date, expectation',
+    [
+        pytest.param('2020/12/17', pytest.raises(ValueError), id='course_open_date_invalid_format'),
+        pytest.param('1/1/2019', pytest.raises(ValueError), id='course_open_date_lt_start_date'),
+        pytest.param('1/1/2022', pytest.raises(ValueError), id='course_open_date_gt_end_date'),
+    ]
+)
+def test_validate_course_open_date_exceptions(course_open_date_settings_fixture, course_open_date, expectation):
+    """Test all cases where function can raise exceptions"""
+    with expectation:
+        validate_course_open_date(course_open_date_settings_fixture, course_open_date)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    'course_open_date, expected',
+    [
+        pytest.param('', None, id='course_open_date_empty'),
+        pytest.param('1/1/2020', datetime(2020, 1, 1, tzinfo=UTC), id='successfully'),
+    ]
+)
+def test_validate_course_open_date(course_open_date_settings_fixture, course_open_date, expected):
+    """Test cases for success case and when course_open_date is empty"""
+    assert validate_course_open_date(course_open_date_settings_fixture, course_open_date) == expected

--- a/common/djangoapps/custom_settings/tests/test_models.py
+++ b/common/djangoapps/custom_settings/tests/test_models.py
@@ -1,0 +1,43 @@
+import pytest
+
+from .factories import CustomSettingsFactory
+
+
+@pytest.mark.django_db
+def test_save_custom_settings_and_no_prior_course_short_id():
+    """Assert that course short id is set to 100, when CustomSettings is saved"""
+    custom_settings = CustomSettingsFactory(course_short_id=None)
+    assert custom_settings.course_short_id == 100
+
+
+@pytest.mark.django_db
+def test_save_custom_settings_increment_course_short_id():
+    """Assert that course short id is incremented properly when CustomSettings is saved"""
+    CustomSettingsFactory(course_short_id=200)
+    CustomSettingsFactory(course_short_id=300)
+    custom_settings = CustomSettingsFactory(course_short_id=None)
+    assert custom_settings.course_short_id == 301
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    'seo_tags, expected',
+    [
+        pytest.param(
+            '{"title":"test", "description":"test", "keywords":"test", "robots":"test", "utm_tag1":"value1"}',
+            {'title': 'test', 'description': 'test', 'keywords': 'test', 'robots': 'test',
+             'utm_params': {'utm_tag1': 'value1'}},
+            id='all_seo_tags'
+        ),
+        pytest.param(
+            '{"title":"test", "description":"test", "dummy":"dummy"}',
+            {'title': 'test', 'description': 'test', 'keywords': '', 'robots': '', 'utm_params': {}},
+            id='some_seo_tags_and_dummy_tags'
+        )
+    ]
+)
+def test_get_course_meta_tags(seo_tags, expected):
+    """All test cases for course meta tag function"""
+    custom_settings = CustomSettingsFactory(seo_tags=seo_tags)
+    course_meta_tags = custom_settings.get_course_meta_tags()
+    assert course_meta_tags == expected

--- a/common/djangoapps/custom_settings/tests/test_views.py
+++ b/common/djangoapps/custom_settings/tests/test_views.py
@@ -1,0 +1,109 @@
+from datetime import datetime
+from json import dumps
+
+from django.http import HttpResponse
+from django.urls import reverse
+from mock import Mock, patch
+from opaque_keys.edx.keys import CourseKey
+from pytz import UTC
+from rest_framework.status import HTTP_200_OK, HTTP_400_BAD_REQUEST, HTTP_405_METHOD_NOT_ALLOWED
+
+from custom_settings.models import CustomSettings
+from custom_settings.tests.factories import CustomSettingsFactory
+from openedx.features.philu_utils.tests.mixins import PhiluThemeMixin
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory
+
+
+class CustomSettingsTestCase(PhiluThemeMixin, ModuleStoreTestCase):
+
+    def setUp(self):
+        super(CustomSettingsTestCase, self).setUp()
+        self.client.login(username=self.user.username, password=self.user_password)
+        self.course = CourseFactory.create(
+            org='test',
+            course='mth',
+            run='101',
+            enrollment_start=datetime(2013, 1, 1),
+            enrollment_end=datetime(2014, 1, 1),
+            start=datetime(2013, 1, 1),
+            end=datetime(2030, 1, 1),
+            emit_signals=True,
+        )
+        course_id = 'course-v1:test+mth+101'
+        self.course_key = CourseKey.from_string(course_id)
+        self.url = reverse('custom_settings', kwargs={'course_key_string': course_id})
+        CustomSettingsFactory(id=self.course_key, tags='tag1, tag2', course_short_id=200)
+
+    @patch('custom_settings.views.get_course_and_check_access', Mock())
+    def test_course_custom_settings_course_settings_dose_not_exist(self):
+        """Assert that view throws 400 status code when settings are fetched for a course which does not exist"""
+        url = reverse('custom_settings', kwargs={'course_key_string': 'course-v1:test+test+123'})
+        self.assertEqual(self.client.get(url, HTTP_ACCEPT='text/html').status_code, HTTP_400_BAD_REQUEST)
+
+    @patch('custom_settings.views.render_to_response')
+    @patch('custom_settings.views.get_course_and_check_access')
+    @patch('custom_settings.views.get_course_open_date_from_settings')
+    def test_course_custom_settings_get_request(self, mock_get_course_open_date_from_settings,
+                                                mock_get_course_and_check_access,
+                                                mock_render_to_response):
+        """Assert that page shows custom settings successfully"""
+        mock_get_course_open_date_from_settings.return_value = '01/01/2020'
+        mock_get_course_and_check_access.return_value = 'test_value'
+        mock_render_to_response.return_value = HttpResponse()
+        self.client.get(self.url, HTTP_ACCEPT='text/html')
+
+        expected_context = {
+            'custom_settings_url': self.url,
+            'custom_dict': {
+                'enable_enrollment_email': True,
+                'tags': u'tag1, tag2',
+                'is_featured': False,
+                'show_grades': True,
+                'auto_enroll': False,
+                'seo_tags': {u'description': u'test', u'title': u'test'},
+                'course_open_date': '01/01/2020'
+            },
+            'context_course': 'test_value',
+            'course_short_id': 200
+        }
+
+        mock_render_to_response.assert_called_once_with('custom_settings.html', expected_context)
+
+    @patch('custom_settings.views.validate_course_open_date')
+    @patch('custom_settings.views.get_course_and_check_access', Mock())
+    def test_course_custom_settings_post_request(self, mock_validate_course_open_date):
+        """Assert that page accepts custom settings from user and saves them successfully"""
+        mock_validate_course_open_date.return_value = datetime(2020, 02, 02, tzinfo=UTC)
+        custom_settings_data = {
+            'tags': u'tag2, tag3',
+            'is_featured': True,
+            'show_grades': False,
+            'course_open_date': '01/01/2020',
+            'seo_tags': {u'description': u'test', u'title': u'test'},
+            'auto_enroll': True,
+            'enable_enrollment_email': True,
+        }
+        response = self.client.post(
+            self.url,
+            data=dumps(custom_settings_data),
+            content_type='application/json',
+            HTTP_ACCEPT='application/json'
+        )
+
+        custom_settings = CustomSettings.objects.get(id=self.course_key)
+
+        self.assertEqual(response.status_code, HTTP_200_OK)
+        self.assertEqual(custom_settings.tags, 'tag2, tag3')
+        self.assertEqual(custom_settings.is_featured, True)
+        self.assertEqual(custom_settings.show_grades, False)
+        self.assertEqual(custom_settings.course_open_date, datetime(2020, 02, 02, tzinfo=UTC))
+        self.assertEqual(custom_settings.seo_tags, '{"description": "test", "title": "test"}')
+        self.assertEqual(custom_settings.auto_enroll, True)
+        self.assertEqual(custom_settings.enable_enrollment_email, True)
+
+    @patch('custom_settings.views.get_course_and_check_access', Mock())
+    def test_course_custom_settings_delete_request(self):
+        """Assert that http delete request is not allowed"""
+        response = self.client.delete(self.url, content_type='application/json', HTTP_ACCEPT='application/json')
+        self.assertEqual(response.status_code, HTTP_405_METHOD_NOT_ALLOWED)

--- a/openedx/features/partners/tests/factories.py
+++ b/openedx/features/partners/tests/factories.py
@@ -2,7 +2,6 @@ import factory
 from factory.django import DjangoModelFactory
 from faker.providers import internet
 
-from custom_settings.models import CustomSettings
 from lms.djangoapps.onboarding.models import FocusArea, Organization
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
 from openedx.features.course_card.models import CourseCard
@@ -30,20 +29,6 @@ class PartnerUserFactory(DjangoModelFactory):
 
     partner = factory.SubFactory(PartnerFactory)
     user = factory.SubFactory(UserFactory)
-
-
-class CustomSettingsFactory(DjangoModelFactory):
-    class Meta:
-        model = CustomSettings
-
-    is_featured = True
-    show_grades = False
-    enable_enrollment_email = True
-    auto_enroll = True
-    tags = factory.Faker('word')
-    course_short_id = factory.Faker('random_int')
-    seo_tags = factory.Faker('word')
-    course_open_date = factory.Faker('date_time')
 
 
 class PartnerCourseOverviewFactory(CourseOverviewFactory):

--- a/openedx/features/partners/tests/test_helpers.py
+++ b/openedx/features/partners/tests/test_helpers.py
@@ -4,10 +4,10 @@ from django.contrib.auth.models import Permission
 from mock import patch
 from organizations.tests.factories import UserFactory
 
+from custom_settings.tests.factories import CustomSettingsFactory
 from openedx.features.partners import helpers
 from openedx.features.partners.tests.factories import (
     CourseCardFactory,
-    CustomSettingsFactory,
     PartnerCommunityFactory,
     PartnerCourseOverviewFactory,
     PartnerFactory,

--- a/openedx/features/philu_utils/model_factory.py
+++ b/openedx/features/philu_utils/model_factory.py
@@ -1,0 +1,14 @@
+from faker import Faker
+from opaque_keys.edx.keys import CourseKey
+
+fake = Faker()
+
+
+def random_course_key():
+    """
+    Generate a CourseKey object from a random string {3 characters}/{4 digits}/course
+    """
+    return CourseKey.from_string('{random_str}/{random_int}/course'.format(
+        random_str=fake.pystr(max_chars=3),
+        random_int=fake.random_number(digits=4)
+    ))

--- a/openedx/features/philu_utils/py_test.py
+++ b/openedx/features/philu_utils/py_test.py
@@ -1,0 +1,9 @@
+from contextlib import contextmanager
+
+
+@contextmanager
+def does_not_raise():
+    """A no-op context manager to check if no exception is raised in a pytest"""
+    # TODO Once code is upgraded to python 3 delete this function and use its alternate `pytest.does_not_raise()`
+    #  or as defined in https://github.com/pytest-dev/pytest/pull/4682#issuecomment-458616795
+    yield

--- a/openedx/features/philu_utils/tests/test_model_factory.py
+++ b/openedx/features/philu_utils/tests/test_model_factory.py
@@ -1,0 +1,13 @@
+import pytest
+from opaque_keys import InvalidKeyError
+from opaque_keys.edx.keys import CourseKey
+
+from openedx.features.philu_utils.model_factory import random_course_key
+
+
+def test_random_course_key():
+    try:
+        course_key = random_course_key()
+        assert isinstance(course_key, CourseKey)
+    except InvalidKeyError as error:
+        pytest.fail('Invalid course key; {error}'.format(error=error))


### PR DESCRIPTION
### Description

[LP-2180](https://philanthropyu.atlassian.net/browse/LP-2180) Unit test for custom settings app


### Notes

- All unit test for the app included
- A factory for custom settings model was created in partners app, which is moved from there to custom_settings app
- All test for partners app passing
