### PR TITLE
LP-2295 Fix Linting Custom_Fields

### DIFF
--- a/openedx/features/custom_fields/apps.py
+++ b/openedx/features/custom_fields/apps.py
@@ -1,4 +1,4 @@
-""" The module contains thedefault django app config for custom_fields"""
+""" AppConfig of custom_fields app"""
 from django.apps import AppConfig
 
 

--- a/openedx/features/custom_fields/apps.py
+++ b/openedx/features/custom_fields/apps.py
@@ -1,4 +1,4 @@
-""" AppConfig of custom_fields app"""
+"""AppConfig of custom_fields app"""
 from django.apps import AppConfig
 
 

--- a/openedx/features/custom_fields/apps.py
+++ b/openedx/features/custom_fields/apps.py
@@ -1,3 +1,4 @@
+""" The module contains thedefault django app config for custom_fields"""
 from django.apps import AppConfig
 
 

--- a/openedx/features/custom_fields/multiselect_with_other/constants.py
+++ b/openedx/features/custom_fields/multiselect_with_other/constants.py
@@ -1,3 +1,3 @@
-""" This module contains constants to be used within multiselect_with_other"""
+""" All constants for custom_fields app"""
 
 OTHER_FIELD_CHECKBOX_VALUE = 'other_selected'

--- a/openedx/features/custom_fields/multiselect_with_other/constants.py
+++ b/openedx/features/custom_fields/multiselect_with_other/constants.py
@@ -1,3 +1,3 @@
-""" All constants for custom_fields app"""
+"""All constants for custom_fields app"""
 
 OTHER_FIELD_CHECKBOX_VALUE = 'other_selected'

--- a/openedx/features/custom_fields/multiselect_with_other/constants.py
+++ b/openedx/features/custom_fields/multiselect_with_other/constants.py
@@ -1,1 +1,3 @@
+""" This module contains constants to be used within multiselect_with_other"""
+
 OTHER_FIELD_CHECKBOX_VALUE = 'other_selected'

--- a/openedx/features/custom_fields/multiselect_with_other/db/fields.py
+++ b/openedx/features/custom_fields/multiselect_with_other/db/fields.py
@@ -24,7 +24,7 @@ class MultiSelectWithOtherField(MultiSelectField):
     This class is a Django Model field class that supports
     multi select along with other option
     The `other_max_length` parameter is required for this
-    Choice keys can not contain commas and other field can not contain
+    Choice keys cannot contain commas and other field cannot contain
     pipe character i.e. `|`
     """
 
@@ -76,7 +76,7 @@ class MultiSelectWithOtherField(MultiSelectField):
 
     def validate(self, value, model_instance):
         """
-        This function is to validate the input values for multi select field,
+        This function is to validate that the input values for multi select field,
         however we are implementing field with support of other input filed
         we are disabling validations to let other input text(other option)
         pass to the database.
@@ -108,7 +108,7 @@ class MultiSelectWithOtherField(MultiSelectField):
 
     def _check_other_max_length_attribute(self, **kwargs):
         """
-        This function is to validate the MultiSelectWithOtherField has a
+        This function is to validate that the MultiSelectWithOtherField has a
         'other_max_length' attribute.
         :param **kwargs: arguments
         :type **kwargs: dictionary

--- a/openedx/features/custom_fields/multiselect_with_other/db/fields.py
+++ b/openedx/features/custom_fields/multiselect_with_other/db/fields.py
@@ -1,4 +1,4 @@
-"""This module contains django models for field class that supports selecting multiple options from given choices"""
+"""This module contains django models for MultiSelect form field with other option"""
 
 from django.core import exceptions, checks
 from django.utils import six
@@ -21,11 +21,10 @@ class OtherMultiSelectFieldList(MSFList):
 
 class MultiSelectWithOtherField(MultiSelectField):
     """
-    This class is a Django Model field class that supports
-    multi select along with other option
-    The `other_max_length` parameter is required for this
-    Choice keys cannot contain commas and other field cannot contain
-    pipe character i.e. `|`
+    This django model field supports multi select options
+    along with other option, It requires `other_max_length`
+    for other field length. Choices keys cannot contain commas
+    and other option field cannot contain pipe character i.e. `|`
     """
 
     def __init__(self, other_max_length=None, *args, **kwargs):
@@ -91,6 +90,17 @@ class MultiSelectWithOtherField(MultiSelectField):
                 raise exceptions.ValidationError(self.error_messages['invalid_char'] % value)
 
     def to_python(self, value):
+        """
+        This function checks when 'value' is a list simply returns it,
+        when it is a string with multiple options separated by a delimiter
+        it converts it to an instance of OtherMultiSelectFieldList and then returns it
+        and when 'value' is a dictionary it converts it to an instance of MSFList and
+        then returns it
+        :param value: options
+        :type value: list, string or dict
+        :return: list of strings with options
+        :rtype: list
+        """
         choices = dict(self.flatchoices)
         if value:
             if isinstance(value, list):
@@ -108,10 +118,12 @@ class MultiSelectWithOtherField(MultiSelectField):
 
     def _check_other_max_length_attribute(self, **kwargs):
         """
-        This function is to validate that the MultiSelectWithOtherField has an
+        Validates `other_max_length` field
         'other_max_length' attribute.
         :param **kwargs: arguments
         :type **kwargs: dictionary
+        :return: list of errors
+        :rtype: list
          """
         if self.other_max_length is None:
             return [

--- a/openedx/features/custom_fields/multiselect_with_other/db/fields.py
+++ b/openedx/features/custom_fields/multiselect_with_other/db/fields.py
@@ -76,7 +76,7 @@ class MultiSelectWithOtherField(MultiSelectField):
 
     def validate(self, value, model_instance):
         """
-        This function is to validate that the input values for multi select field,
+        This function is to validate the input values for multi select field,
         however we are implementing field with support of other input filed
         we are disabling validations to let other input text(other option)
         pass to the database.
@@ -108,7 +108,7 @@ class MultiSelectWithOtherField(MultiSelectField):
 
     def _check_other_max_length_attribute(self, **kwargs):
         """
-        This function is to validate that the MultiSelectWithOtherField has a
+        This function is to validate that the MultiSelectWithOtherField has an
         'other_max_length' attribute.
         :param **kwargs: arguments
         :type **kwargs: dictionary

--- a/openedx/features/custom_fields/multiselect_with_other/db/fields.py
+++ b/openedx/features/custom_fields/multiselect_with_other/db/fields.py
@@ -1,3 +1,5 @@
+"""This module contains django models for field class that support multi select"""
+
 from django.core import exceptions, checks
 from django.utils import six
 from django.utils.encoding import python_2_unicode_compatible
@@ -18,8 +20,7 @@ class OtherMultiSelectFieldList(MSFList):
 
 
 class MultiSelectWithOtherField(MultiSelectField):
-    """
-        This class is a Django Model field class that supports
+    """This class is a Django Model field class that supports
         multi select along with other option
         The `other_max_length` parameter is required for this
         Choice keys can not contain commas and other field can not contain
@@ -73,15 +74,15 @@ class MultiSelectWithOtherField(MultiSelectField):
         return MultiSelectWithOtherFormField(**defaults)
 
     def validate(self, value, model_instance):
-        """
-        This function is to validate the input values for multi select field,
+        """ This function is to validate the input values for multi select field,
         however we are implementing field with support of other input filed
         we are disabling validations to let other input text(other option)
         pass to the database.
 
         :param value: list of all selected choice with other text.
         :param model_instance: current model instance for with it is saving data.
-        :return: None
+        :type value: list
+        :type model_instance: MultiSelectWithOtherField
         """
         for opt_select in value:
             if self.other_delimiter in opt_select:
@@ -104,6 +105,11 @@ class MultiSelectWithOtherField(MultiSelectField):
         return MSFList(choices, [])
 
     def _check_other_max_length_attribute(self, **kwargs):
+        """ This function is to validate the MultiSelectWithOtherField has a
+        'other_max_length' attribute.
+        :param **kwargs: arguments
+        :type **kwargs: dictionary
+         """
         if self.other_max_length is None:
             return [
                 checks.Error(

--- a/openedx/features/custom_fields/multiselect_with_other/db/fields.py
+++ b/openedx/features/custom_fields/multiselect_with_other/db/fields.py
@@ -1,4 +1,4 @@
-"""This module contains django models for field class that support multi select"""
+"""This module contains django models for field class that supports selecting multiple options from given choices"""
 
 from django.core import exceptions, checks
 from django.utils import six
@@ -20,11 +20,12 @@ class OtherMultiSelectFieldList(MSFList):
 
 
 class MultiSelectWithOtherField(MultiSelectField):
-    """This class is a Django Model field class that supports
-        multi select along with other option
-        The `other_max_length` parameter is required for this
-        Choice keys can not contain commas and other field can not contain
-        pipe character i.e. `|`
+    """
+    This class is a Django Model field class that supports
+    multi select along with other option
+    The `other_max_length` parameter is required for this
+    Choice keys can not contain commas and other field can not contain
+    pipe character i.e. `|`
     """
 
     def __init__(self, other_max_length=None, *args, **kwargs):
@@ -74,7 +75,8 @@ class MultiSelectWithOtherField(MultiSelectField):
         return MultiSelectWithOtherFormField(**defaults)
 
     def validate(self, value, model_instance):
-        """ This function is to validate the input values for multi select field,
+        """
+        This function is to validate the input values for multi select field,
         however we are implementing field with support of other input filed
         we are disabling validations to let other input text(other option)
         pass to the database.
@@ -105,7 +107,8 @@ class MultiSelectWithOtherField(MultiSelectField):
         return MSFList(choices, [])
 
     def _check_other_max_length_attribute(self, **kwargs):
-        """ This function is to validate the MultiSelectWithOtherField has a
+        """
+        This function is to validate the MultiSelectWithOtherField has a
         'other_max_length' attribute.
         :param **kwargs: arguments
         :type **kwargs: dictionary

--- a/openedx/features/custom_fields/multiselect_with_other/forms/fields.py
+++ b/openedx/features/custom_fields/multiselect_with_other/forms/fields.py
@@ -1,4 +1,4 @@
-""" This module contains formfield for to select multiple options from given choices"""
+""" This module contains formfield to select multiple options from given choices"""
 
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext_lazy as _

--- a/openedx/features/custom_fields/multiselect_with_other/forms/fields.py
+++ b/openedx/features/custom_fields/multiselect_with_other/forms/fields.py
@@ -1,3 +1,5 @@
+""" This module contains formfield for multi select"""
+
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext_lazy as _
 from multiselectfield import MultiSelectFormField
@@ -14,8 +16,7 @@ from openedx.features.custom_fields.multiselect_with_other.helpers import (
 
 
 class MultiSelectWithOtherFormField(MultiSelectFormField):
-    """
-    Form field class to handle other text input field within the multiselect field
+    """ Form field class to handle other text input field within the multiselect field
     """
 
     def __init__(self, other_max_length=None, *args, **kwargs):
@@ -37,8 +38,10 @@ class MultiSelectWithOtherFormField(MultiSelectFormField):
         return len(value) <= self.other_max_length
 
     def validate(self, value):
-        """
-        Validate that the input is a list or tuple.
+        """ Validate that the input is a list or tuple.
+        :param value: list of selected choices
+        :type value: list
+        :raise ValidationError: Validation Error
         """
         if self.required and not value:
             raise ValidationError(self.error_messages['required'], code='required')
@@ -54,13 +57,24 @@ class MultiSelectWithOtherFormField(MultiSelectFormField):
                     )
 
     def to_python(self, value):
-        """
-        Returns a list of strings
+        """ This function filters for the value that is automatically put
+        into the form payload when other field is selected in usage of
+        MultiSelectWithOtherField
+        :param value: list of strings
+        :type value: list
+        :return: list of strings with the other field checkbox value removed
+        :rtype: list
         """
         return filter_other_field_checkbox_value(
             super(MultiSelectWithOtherFormField, self).to_python(value)
         )
 
     def clean(self, value):
+        """ Return values that are not empty
+        :param value: list of selected choices
+        :type value: list
+        :return: values that are not empty
+        :rtype: list
+        """
         value = [val for val in value if val not in self.empty_values]
         return super(MultiSelectWithOtherFormField, self).clean(value)

--- a/openedx/features/custom_fields/multiselect_with_other/forms/fields.py
+++ b/openedx/features/custom_fields/multiselect_with_other/forms/fields.py
@@ -37,7 +37,8 @@ class MultiSelectWithOtherFormField(MultiSelectFormField):
         return len(value) <= self.other_max_length
 
     def validate(self, value):
-        """ Validate that the input is a list or tuple.
+        """
+        Validate that the input is a list or tuple.
         :param value: list or tuple of selected choices
         :type value: list or tuple
         :raise ValidationError: Raise validation error when required value not provided

--- a/openedx/features/custom_fields/multiselect_with_other/forms/fields.py
+++ b/openedx/features/custom_fields/multiselect_with_other/forms/fields.py
@@ -1,4 +1,4 @@
-""" This module contains formfield for multi select"""
+""" This module contains formfield for to select multiple options from given choices"""
 
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext_lazy as _
@@ -16,8 +16,7 @@ from openedx.features.custom_fields.multiselect_with_other.helpers import (
 
 
 class MultiSelectWithOtherFormField(MultiSelectFormField):
-    """ Form field class to handle other text input field within the multiselect field
-    """
+    """ Form field class to handle other text input field within the multiselect field"""
 
     def __init__(self, other_max_length=None, *args, **kwargs):
         if kwargs.get('choices'):
@@ -39,9 +38,9 @@ class MultiSelectWithOtherFormField(MultiSelectFormField):
 
     def validate(self, value):
         """ Validate that the input is a list or tuple.
-        :param value: list of selected choices
-        :type value: list
-        :raise ValidationError: Validation Error
+        :param value: list or tuple of selected choices
+        :type value: list or tuple
+        :raise ValidationError: Raise validation error when required value not provided
         """
         if self.required and not value:
             raise ValidationError(self.error_messages['required'], code='required')
@@ -57,7 +56,8 @@ class MultiSelectWithOtherFormField(MultiSelectFormField):
                     )
 
     def to_python(self, value):
-        """ This function filters for the value that is automatically put
+        """
+        This function filters for the value that is automatically put
         into the form payload when other field is selected in usage of
         MultiSelectWithOtherField
         :param value: list of strings
@@ -70,7 +70,8 @@ class MultiSelectWithOtherFormField(MultiSelectFormField):
         )
 
     def clean(self, value):
-        """ Return values that are not empty
+        """
+        Return values that are not empty
         :param value: list of selected choices
         :type value: list
         :return: values that are not empty

--- a/openedx/features/custom_fields/multiselect_with_other/forms/fields.py
+++ b/openedx/features/custom_fields/multiselect_with_other/forms/fields.py
@@ -1,4 +1,4 @@
-""" This module contains formfield to select multiple options from given choices"""
+"""This module contains MultiSelect form field with other option"""
 
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext_lazy as _
@@ -16,7 +16,7 @@ from openedx.features.custom_fields.multiselect_with_other.helpers import (
 
 
 class MultiSelectWithOtherFormField(MultiSelectFormField):
-    """ Form field class to handle other text input field within the multiselect field"""
+    """ FormField for multiselect with other option"""
 
     def __init__(self, other_max_length=None, *args, **kwargs):
         if kwargs.get('choices'):
@@ -38,7 +38,8 @@ class MultiSelectWithOtherFormField(MultiSelectFormField):
 
     def validate(self, value):
         """
-        Validate that the input is a list or tuple.
+        Validates the MultiSelectWithOtherFormField like
+        required and other field if other option is selected
         :param value: list or tuple of selected choices
         :type value: list or tuple
         :raise ValidationError: Raise validation error when required value not provided

--- a/openedx/features/custom_fields/multiselect_with_other/forms/widgets.py
+++ b/openedx/features/custom_fields/multiselect_with_other/forms/widgets.py
@@ -1,4 +1,4 @@
-""" This module implements functionality to handle widgets"""
+"""This module implements the Radio and Checkbox widgets for MultiSelectWithOther field"""
 from django.forms.widgets import CheckboxSelectMultiple
 
 from openedx.features.custom_fields.multiselect_with_other.helpers import (
@@ -8,7 +8,7 @@ from openedx.features.custom_fields.multiselect_with_other.helpers import (
 
 
 class CheckboxSelectMultipleWithOther(CheckboxSelectMultiple):
-    """ Widget class to handle other value filed."""
+    """ Implements checkbox widget for MultiSelectWithOther field"""
     other_choice = None
     other_option_template_name = 'other_field.html'
 
@@ -46,6 +46,8 @@ class CheckboxSelectMultipleWithOther(CheckboxSelectMultiple):
 
 
 class RadioSelectWithOther(CheckboxSelectMultipleWithOther):
+    """ Implements radio select widget for MultiSelectWithOther field"""
+    
     def create_option(self, name, value, label, selected, index, subindex=None, attrs=None):
         option = super(RadioSelectWithOther, self).create_option(name, value, label, selected, index, subindex, attrs)
 

--- a/openedx/features/custom_fields/multiselect_with_other/forms/widgets.py
+++ b/openedx/features/custom_fields/multiselect_with_other/forms/widgets.py
@@ -8,8 +8,7 @@ from openedx.features.custom_fields.multiselect_with_other.helpers import (
 
 
 class CheckboxSelectMultipleWithOther(CheckboxSelectMultiple):
-    """ Widget class to handle other value filed.
-    """
+    """ Widget class to handle other value filed."""
     other_choice = None
     other_option_template_name = 'other_field.html'
 
@@ -29,8 +28,7 @@ class CheckboxSelectMultipleWithOther(CheckboxSelectMultiple):
         return option
 
     def optgroups(self, name, value, attrs=None):
-        """ Return a list of optgroups for this widget.
-        """
+        """ Return a list of optgroups for this widget."""
 
         other_values = get_other_values(self.choices, value)
 

--- a/openedx/features/custom_fields/multiselect_with_other/forms/widgets.py
+++ b/openedx/features/custom_fields/multiselect_with_other/forms/widgets.py
@@ -1,3 +1,4 @@
+""" This module implements functionality to handle widgets"""
 from django.forms.widgets import CheckboxSelectMultiple
 
 from openedx.features.custom_fields.multiselect_with_other.helpers import (
@@ -7,8 +8,7 @@ from openedx.features.custom_fields.multiselect_with_other.helpers import (
 
 
 class CheckboxSelectMultipleWithOther(CheckboxSelectMultiple):
-    """
-    Widget class to handle other value filed.
+    """ Widget class to handle other value filed.
     """
     other_choice = None
     other_option_template_name = 'other_field.html'
@@ -29,8 +29,7 @@ class CheckboxSelectMultipleWithOther(CheckboxSelectMultiple):
         return option
 
     def optgroups(self, name, value, attrs=None):
-        """
-        Return a list of optgroups for this widget.
+        """ Return a list of optgroups for this widget.
         """
 
         other_values = get_other_values(self.choices, value)

--- a/openedx/features/custom_fields/multiselect_with_other/helpers.py
+++ b/openedx/features/custom_fields/multiselect_with_other/helpers.py
@@ -1,14 +1,15 @@
-""" This module contains helper functions for multi_select_With_other"""
+""" All helpers for custom_fields app"""
 
 from openedx.features.custom_fields.multiselect_with_other.constants import OTHER_FIELD_CHECKBOX_VALUE
 
 
 def add_other_field_in_choices(choices):
-    """ This function to separate other's value from list of choices
+    """
+    This function is adding other's value to list of choices
     :param choices: list of choices
     :type choices: list
-    :return: list with other field.
-    :rtype: list
+    :return: list, dict or tuple with other field.
+    :rtype: list, dict or tuple
     """
     _choices = choices
 
@@ -28,13 +29,14 @@ def add_other_field_in_choices(choices):
 
 
 def get_other_values(choices, value):
-    """ This function to separate other's value from list of choices
+    """
+    This function to separate other's value from list of choices
     :param choices: list of valid choices
     :param value: list of selected choices including other's value
     :type choices: list
     :type value: list
-    :return: list of other values.
-    :rtype: list
+    :return: list, dict or tuple with other field.
+    :rtype: list, dict or tuple
     """
     choice_values = [choice[0] for choice in choices]
     other_values = [val for val in value if val not in choice_values]
@@ -42,7 +44,8 @@ def get_other_values(choices, value):
 
 
 def filter_other_field_checkbox_value(values):
-    """ This function filters for the value that is automatically put
+    """
+    This function filters for the value that is automatically put
     into the form payload when other field is selected in usage of
     MultiSelectWithOtherField
     :param values: list of strings

--- a/openedx/features/custom_fields/multiselect_with_other/helpers.py
+++ b/openedx/features/custom_fields/multiselect_with_other/helpers.py
@@ -1,11 +1,11 @@
-""" All helpers for custom_fields app"""
+"""All helpers for custom_fields app"""
 
 from openedx.features.custom_fields.multiselect_with_other.constants import OTHER_FIELD_CHECKBOX_VALUE
 
 
 def add_other_field_in_choices(choices):
     """
-    This function is adding other's value to list of choices
+    This adds other option in multi select choices
     :param choices: list of choices
     :type choices: list
     :return: list, dict or tuple with other field.

--- a/openedx/features/custom_fields/multiselect_with_other/helpers.py
+++ b/openedx/features/custom_fields/multiselect_with_other/helpers.py
@@ -1,7 +1,15 @@
+""" This module contains helper functions for multi_select_With_other"""
+
 from openedx.features.custom_fields.multiselect_with_other.constants import OTHER_FIELD_CHECKBOX_VALUE
 
 
 def add_other_field_in_choices(choices):
+    """ This function to separate other's value from list of choices
+    :param choices: list of choices
+    :type choices: list
+    :return: list with other field.
+    :rtype: list
+    """
     _choices = choices
 
     if isinstance(_choices, dict):
@@ -20,11 +28,13 @@ def add_other_field_in_choices(choices):
 
 
 def get_other_values(choices, value):
-    """
-    This function to separate other's value from list of choices
+    """ This function to separate other's value from list of choices
     :param choices: list of valid choices
     :param value: list of selected choices including other's value
+    :type choices: list
+    :type value: list
     :return: list of other values.
+    :rtype: list
     """
     choice_values = [choice[0] for choice in choices]
     other_values = [val for val in value if val not in choice_values]
@@ -32,12 +42,13 @@ def get_other_values(choices, value):
 
 
 def filter_other_field_checkbox_value(values):
-    """
-    This function filters for the value that is automatically put
+    """ This function filters for the value that is automatically put
     into the form payload when other field is selected in usage of
     MultiSelectWithOtherField
     :param values: list of strings
+    :type values: list
     :return: list of strings with the OTHER_FIELD_CHECKBOX_VALUE removed
+    :rtype: list
     """
     if isinstance(values, list) and OTHER_FIELD_CHECKBOX_VALUE in values:
         values.remove(OTHER_FIELD_CHECKBOX_VALUE)


### PR DESCRIPTION
### Description

[LP-2295](https://philanthropyu.atlassian.net/browse/LP-2295)

### Linting Report

************* Module edx-platform.openedx.features.custom_fields.apps
C:  1, 0: Missing module docstring (missing-docstring)
************* Module edx-platform.openedx.features.custom_fields.multiselect_with_other.constants
C:  1, 0: Missing module docstring (missing-docstring)
************* Module edx-platform.openedx.features.custom_fields.multiselect_with_other.helpers
C:  1, 0: Missing module docstring (missing-docstring)
C:  4, 0: Missing function docstring (missing-docstring)
W: 22, 0: "choices, value" missing in parameter type documentation (missing-type-doc)
W: 22, 0: Missing return type documentation (missing-return-type-doc)
W: 34, 0: "values" missing in parameter type documentation (missing-type-doc)
W: 34, 0: Missing return type documentation (missing-return-type-doc)
************* Module edx-platform.openedx.features.custom_fields.multiselect_with_other.forms.fields
C:  1, 0: Missing module docstring (missing-docstring)
E: 31,32: Instance of '__proxy__' has no 'format' member (no-member)
************* Module edx-platform.openedx.features.custom_fields.multiselect_with_other.forms.widgets
C:  1, 0: Missing module docstring (missing-docstring)
************* Module edx-platform.openedx.features.custom_fields.multiselect_with_other.db.fields
C:  1, 0: Missing module docstring (missing-docstring)
W: 75, 4: "model_instance, value" missing in parameter type documentation (missing-type-doc)
W: 75, 4: Redundant returns documentation (redundant-returns-doc)
W:106, 0: Unused argument 'kwargs' (unused-argument)
