### PR TITLE
LP-2292 Fixing all linting issues for openedx teams app

### DIFF
--- a/openedx/features/teams/decorators.py
+++ b/openedx/features/teams/decorators.py
@@ -1,3 +1,4 @@
+""" Decorators for teams application """
 from django.core.urlresolvers import reverse
 from django.shortcuts import redirect
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
@@ -6,8 +7,10 @@ from lms.djangoapps.courseware.courses import get_course_by_id
 
 
 def can_view_teams(function):
-    def wrap(request, *args, **kwargs):
-
+    """ If course has ended redirect user to teams dashboard, otherwise proceed normally. For the parameters,
+    see PEP 318
+    """
+    def wrap(request, *args, **kwargs):  # pylint: disable=missing-docstring
         course_id = SlashSeparatedCourseKey.from_deprecated_string(kwargs['course_id'])
         course = get_course_by_id(course_id)
 

--- a/openedx/features/teams/decorators.py
+++ b/openedx/features/teams/decorators.py
@@ -1,7 +1,8 @@
 from django.core.urlresolvers import reverse
 from django.shortcuts import redirect
-from lms.djangoapps.courseware.courses import get_course_by_id
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
+
+from lms.djangoapps.courseware.courses import get_course_by_id
 
 
 def can_view_teams(function):

--- a/openedx/features/teams/decorators.py
+++ b/openedx/features/teams/decorators.py
@@ -1,4 +1,6 @@
-""" Decorators for teams application """
+"""
+Decorators for teams application
+"""
 from django.core.urlresolvers import reverse
 from django.shortcuts import redirect
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
@@ -7,7 +9,8 @@ from lms.djangoapps.courseware.courses import get_course_by_id
 
 
 def can_view_teams(function):
-    """ If course has ended redirect user to teams dashboard, otherwise proceed normally. For the parameters,
+    """
+    If course has ended redirect user to teams dashboard, otherwise proceed normally. For the parameters,
     see PEP 318
     """
     def wrap(request, *args, **kwargs):  # pylint: disable=missing-docstring

--- a/openedx/features/teams/helpers.py
+++ b/openedx/features/teams/helpers.py
@@ -1,4 +1,6 @@
-""" Helpers for teams application"""
+"""
+Helpers for teams application
+"""
 from random import choice
 
 from django.conf import settings
@@ -20,7 +22,9 @@ TEAM_BANNER_COLORS = [
 
 
 def serialize(queryset, request, serializer_cls, serializer_ctx, many=True):
-    """ Serialize and paginate objects in a queryset.
+    """
+    Serialize and paginate objects in a queryset.
+
     :param QuerySet queryset: QuerySet of model
     :param HttpRequest request: http request
     :param class serializer_cls: Django Rest Framework Serializer subclass.
@@ -36,7 +40,9 @@ def serialize(queryset, request, serializer_cls, serializer_ctx, many=True):
 
 
 def generate_random_user_icon_color():
-    """ Create random color code form given choices
+    """
+    Create random color code form given choices
+
     :return: Color code i.e. #f44336
     :rtype: string
     """
@@ -44,7 +50,9 @@ def generate_random_user_icon_color():
 
 
 def generate_random_team_banner_color():
-    """ Create random color code form given choices
+    """
+    Create random color code form given choices
+
     :return: Color code i.e. #f44336
     :rtype: string
     """
@@ -52,8 +60,10 @@ def generate_random_team_banner_color():
 
 
 def make_embed_url(team_group_chat, user, topic_url=None):
-    """ Create an embeddable url, for team group chat, to embed into iFrame. First try to make url from topic_url,
-    if it is None then from team_group_chat slug and if both are None then from room id.
+    """
+    Create an embeddable url, for team group chat, to embed into iFrame. First try to make url from topic_url,
+    if it is None then from `team_group_chat` slug and if both are None then from room id.
+
     :param TeamGroupChat team_group_chat: Team group chat object
     :param User user: User object
     :param string topic_url: Topic url extracted from http request
@@ -72,7 +82,9 @@ def make_embed_url(team_group_chat, user, topic_url=None):
 
 
 def get_user_recommended_team(course_key, user):
-    """ Get recommended teams for the user
+    """
+    Get recommended teams for the user
+
     :param CourseKey course_key: Course key object
     :param User user: user object
     :return: List of recommended teams
@@ -86,8 +98,10 @@ def get_user_recommended_team(course_key, user):
 
 
 def get_user_course_with_access(course_id, user):
-    """ Method that wraps the courseware.courses.get_course_with_access to use
-    course_id in string format with it
+    """
+    Method that wraps the `courseware.courses.get_course_with_access` to use
+    `course_id` in string format with it
+
     :param string course_id: Id of a course
     :param User user: User object
     :return: course if user has access in this course
@@ -98,7 +112,9 @@ def get_user_course_with_access(course_id, user):
 
 
 def get_team_topic(course, topic_id):
-    """ Get topic by topic_id from course
+    """
+    Get topic by `topic_id` from course
+
     :param Course course: course object
     :param string topic_id: Topic id
     :return: A valid topic in a course else None

--- a/openedx/features/teams/helpers.py
+++ b/openedx/features/teams/helpers.py
@@ -1,9 +1,10 @@
 from random import choice
-from django.conf import settings
 
+from django.conf import settings
 from opaque_keys.edx.keys import CourseKey
-from lms.djangoapps.teams.models import CourseTeam
+
 from courseware.courses import get_course_with_access
+from lms.djangoapps.teams.models import CourseTeam
 
 USER_ICON_COLORS = [
     '#f44336', '#e91e63', '#9c27b0', '#673ab7', '#3f51b5',

--- a/openedx/features/teams/helpers.py
+++ b/openedx/features/teams/helpers.py
@@ -1,3 +1,4 @@
+""" Helpers for teams application"""
 from random import choice
 
 from django.conf import settings
@@ -19,33 +20,46 @@ TEAM_BANNER_COLORS = [
 
 
 def serialize(queryset, request, serializer_cls, serializer_ctx, many=True):
+    """ Serialize and paginate objects in a queryset.
+    :param QuerySet queryset: QuerySet of model
+    :param HttpRequest request: http request
+    :param class serializer_cls: Django Rest Framework Serializer subclass.
+    :param dict serializer_ctx: Context dictionary to pass to the serializer
+    :param bool many: True, to serialize a queryset or list of objects instead of a single object instance
+    :return: serialized data
+    :rtype: json
     """
-    Serialize and paginate objects in a queryset.
-
-    Arguments:
-        serializer_cls (serializers.Serializer class): Django Rest Framework Serializer subclass.
-        serializer_ctx (dict): Context dictionary to pass to the serializer
-        many (bool):
-
-    Returns: dict
-
-    """
-    # Serialize
-    serializer_ctx["request"] = request
+    serializer_ctx["request"] = request  # Serialize
 
     serializer = serializer_cls(queryset, context=serializer_ctx, many=many)
     return serializer.data
 
 
 def generate_random_user_icon_color():
+    """ Create random color code form given choices
+    :return: Color code i.e. #f44336
+    :rtype: string
+    """
     return choice(USER_ICON_COLORS)
 
 
 def generate_random_team_banner_color():
+    """ Create random color code form given choices
+    :return: Color code i.e. #f44336
+    :rtype: string
+    """
     return choice(TEAM_BANNER_COLORS)
 
 
 def make_embed_url(team_group_chat, user, topic_url=None):
+    """ Create team group chat room embed url to embed into iFrame. First try to make url from topic_url, if it is none
+    then from team_group_chat slug and if both are none then from room id.
+    :param TeamGroupChat team_group_chat: Team group chat object
+    :param User user: User object
+    :param string topic_url: Topic url extracted from http request
+    :return: An embed url
+    :rtype: string
+    """
     if topic_url:
         topic = topic_url.split("topic/")[1]
         return '{}/embed/{}?iframe=embedView&isTopic=True'.format(settings.NODEBB_ENDPOINT, topic)
@@ -58,6 +72,12 @@ def make_embed_url(team_group_chat, user, topic_url=None):
 
 
 def get_user_recommended_team(course_key, user):
+    """ Get recommended teams for the user
+    :param CourseKey course_key: Course key object
+    :param User user: user object
+    :return: List of recommended teams
+    :rtype: list
+    """
     user_country = user.profile.country
     recommended_teams = CourseTeam.objects.filter(course_id=course_key,
                                                   country=user_country).exclude(users__in=[user]).all()
@@ -66,21 +86,26 @@ def get_user_recommended_team(course_key, user):
 
 
 def get_user_course_with_access(course_id, user):
-    """
-    Method that wraps the courseware.courses.get_course_with_access to use
+    """ Method that wraps the courseware.courses.get_course_with_access to use
     course_id in string format with it
-
-    :param course_id: in string format
-    :param user: user
+    :param string course_id: Id of a course
+    :param User user: User object
     :return: course if user has access in this course
+    :rtype: Course
     """
     course_key = CourseKey.from_string(course_id)
     return get_course_with_access(user, "load", course_key)
 
 
 def get_team_topic(course, topic_id):
+    """ Get topic by topic_id from course
+    :param Course course: course object
+    :param string topic_id: Topic id
+    :return: A valid topic in a course else None
+    :rtype: dict or None
+    """
     if not topic_id:
         return
 
-    topics = filter(lambda topic: topic['id'] == topic_id, course.teams_topics) or (None,)
+    topics = [topic for topic in course.teams_topics if topic['id'] == topic_id] or (None,)
     return topics[0]

--- a/openedx/features/teams/helpers.py
+++ b/openedx/features/teams/helpers.py
@@ -52,12 +52,12 @@ def generate_random_team_banner_color():
 
 
 def make_embed_url(team_group_chat, user, topic_url=None):
-    """ Create team group chat room embed url to embed into iFrame. First try to make url from topic_url, if it is none
-    then from team_group_chat slug and if both are none then from room id.
+    """ Create an embeddable url, for team group chat, to embed into iFrame. First try to make url from topic_url,
+    if it is None then from team_group_chat slug and if both are None then from room id.
     :param TeamGroupChat team_group_chat: Team group chat object
     :param User user: User object
     :param string topic_url: Topic url extracted from http request
-    :return: An embed url
+    :return: An embeddable url
     :rtype: string
     """
     if topic_url:

--- a/openedx/features/teams/mixins.py
+++ b/openedx/features/teams/mixins.py
@@ -1,11 +1,14 @@
-""" Mixins for the teams application. """
+"""
+Mixins for the teams application.
+"""
 from edx_rest_framework_extensions.auth.session.authentication import SessionAuthenticationAllowInactiveUser
 
 from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser
 
 
 class AllowInActiveUserAuthMixin(object):
-    """ OAuth2AuthenticationAllowInactiveUser must come first to return a 401 for unauthenticated users
+    """
+    OAuth2AuthenticationAllowInactiveUser must come first to return a 401 for unauthenticated users
     use OAuth2AuthenticationAllowInactiveUser, SessionAuthenticationAllowInactiveUser instead of
     OAuth2Authentication, SessionAuthentication to allow access to inactive user
     """

--- a/openedx/features/teams/mixins.py
+++ b/openedx/features/teams/mixins.py
@@ -1,4 +1,5 @@
 from edx_rest_framework_extensions.auth.session.authentication import SessionAuthenticationAllowInactiveUser
+
 from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser
 
 

--- a/openedx/features/teams/mixins.py
+++ b/openedx/features/teams/mixins.py
@@ -1,11 +1,11 @@
+""" Mixins for the teams application. """
 from edx_rest_framework_extensions.auth.session.authentication import SessionAuthenticationAllowInactiveUser
 
 from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser
 
 
 class AllowInActiveUserAuthMixin(object):
-    """
-    OAuth2AuthenticationAllowInactiveUser must come first to return a 401 for unauthenticated users
+    """ OAuth2AuthenticationAllowInactiveUser must come first to return a 401 for unauthenticated users
     use OAuth2AuthenticationAllowInactiveUser, SessionAuthenticationAllowInactiveUser instead of
     OAuth2Authentication, SessionAuthentication to allow access to inactive user
     """

--- a/openedx/features/teams/serializers.py
+++ b/openedx/features/teams/serializers.py
@@ -1,4 +1,6 @@
-""" Serializers for teams application """
+"""
+Serializers for teams application
+"""
 from django.conf import settings
 from django.contrib.humanize.templatetags.humanize import naturaltime
 from rest_framework import serializers
@@ -14,14 +16,18 @@ from .helpers import generate_random_team_banner_color, generate_random_user_ico
 
 
 class CustomCountryField(CountryField):
-    """ Field to serialize country code """
+    """
+    Field to serialize country code
+    """
 
     def to_internal_value(self, data):
-        """ Check that the code is a valid country code.
+        """
+        Check that the code is a valid country code.
 
         We leave the data in its original format so that the Django model's
         CountryField can convert it to the internal representation used
         by the django-countries library.
+
         :param dict data: Country code
         :return: Valid country code
         :rtype: dict
@@ -40,12 +46,16 @@ class CustomCountryField(CountryField):
 
 
 class CustomLanguageField(serializers.Field):
-    """ Field to serialize a Language code. """
+    """
+    Field to serialize a Language code
+    """
 
     LANGUAGE_CODES = dict(settings.ALL_LANGUAGES).keys()
 
     def to_representation(self, value):
-        """ Represent the country as a 2-character unicode identifier.
+        """
+        Represent the country as a 2-character unicode identifier.
+
         :param (char) value: Field value
         :return: Unicode representation of value
         :rtype: unicode
@@ -53,11 +63,13 @@ class CustomLanguageField(serializers.Field):
         return unicode(value)
 
     def to_internal_value(self, data):
-        """ Check that the code is a valid language code.
+        """
+        Check that the code is a valid language code.
 
         We leave the data in its original format so that the Django model's
         CountryField can convert it to the internal representation used
         by the django-countries library.
+
         :param dict data: Language code
         :return: Valid language code
         :rtype: dict
@@ -76,13 +88,17 @@ class CustomLanguageField(serializers.Field):
 
 
 class CustomCourseTeamCreationSerializer(CourseTeamCreationSerializer):
-    """ Custom serializer for course team creation """
+    """
+    Custom serializer for course team creation
+    """
     country = CustomCountryField(required=True)
     language = CustomLanguageField(required=True)
 
 
 class CustomUserMembershipSerializer(UserMembershipSerializer):
-    """ Custom serializer for user membership inherittes from CourseTeamMembership"""
+    """
+    Custom serializer for user membership inherits from CourseTeamMembership
+    """
     class Meta(object):
         model = UserMembershipSerializer.Meta.model
         fields = UserMembershipSerializer.Meta.fields + (
@@ -95,7 +111,9 @@ class CustomUserMembershipSerializer(UserMembershipSerializer):
     date_joined_natural = serializers.SerializerMethodField()
 
     def get_profile_color(self, membership):  # pylint: disable=unused-argument
-        """ Get profile color
+        """
+        Get profile color
+
         :param CourseTeamMembership membership: Course team membership model object
         :return: Hex color code , i.e #FFFFFF
         :rtype: string
@@ -103,7 +121,9 @@ class CustomUserMembershipSerializer(UserMembershipSerializer):
         return generate_random_user_icon_color()
 
     def get_last_activity_natural(self, membership):
-        """ Get last activity time in human readable format i.e. a minute ago, 2 hours ago etc
+        """
+        Get last activity time in human readable format i.e. a minute ago, 2 hours ago etc
+
         :param CourseTeamMembership membership: Course team membership model object
         :return: Natural date time
         :rtype: string
@@ -111,7 +131,9 @@ class CustomUserMembershipSerializer(UserMembershipSerializer):
         return naturaltime(membership.last_activity_at)
 
     def get_date_joined_natural(self, membership):
-        """ Get joined date time in human readable format i.e. a minute ago, 2 hours ago etc
+        """
+        Get joined date time in human readable format i.e. a minute ago, 2 hours ago etc
+
         :param CourseTeamMembership membership: Course team membership model object
         :return: Natural date time
         :rtype: string
@@ -120,7 +142,9 @@ class CustomUserMembershipSerializer(UserMembershipSerializer):
 
 
 class CustomCourseTeamSerializer(CourseTeamSerializer):
-    """ Custom serializer for course team """
+    """
+    Custom serializer for course team
+    """
     country = serializers.SerializerMethodField()
     language = serializers.SerializerMethodField()
     banner_color = serializers.SerializerMethodField()
@@ -132,7 +156,9 @@ class CustomCourseTeamSerializer(CourseTeamSerializer):
         read_only_fields = CourseTeamSerializer.Meta.read_only_fields
 
     def get_country(self, course_team):
-        """ Get course team banner country
+        """
+        Get course team banner country
+
         :param CourseTeam course_team: Course team model object
         :return: Country name
         :rtype: string
@@ -140,7 +166,9 @@ class CustomCourseTeamSerializer(CourseTeamSerializer):
         return course_team.country.name.format()
 
     def get_language(self, course_team):
-        """ Get valid corresponding language from settings otherwise return course team language
+        """
+        Get valid corresponding language from settings otherwise return course team language
+
         :param CourseTeam course_team: Course team model object
         :return: Course team language
         :rtype: list
@@ -152,7 +180,9 @@ class CustomCourseTeamSerializer(CourseTeamSerializer):
             return course_team.language
 
     def get_banner_color(self, course_team):  # pylint: disable=unused-argument
-        """ Get course team banner color
+        """
+        Get course team banner color
+
         :param CourseTeam course_team: Course team model object
         :return: Hex color code , i.e #FFFFFF
         :rtype: string

--- a/openedx/features/teams/serializers.py
+++ b/openedx/features/teams/serializers.py
@@ -1,4 +1,4 @@
-"""Defines serializers used by the Team API."""
+""" Serializers for teams application """
 from django.conf import settings
 from django.contrib.humanize.templatetags.humanize import naturaltime
 from rest_framework import serializers
@@ -14,17 +14,17 @@ from .helpers import generate_random_team_banner_color, generate_random_user_ico
 
 
 class CustomCountryField(CountryField):
-    """
-    Field to serialize a country code.
-    """
+    """ Field to serialize country code """
 
     def to_internal_value(self, data):
-        """
-        Check that the code is a valid country code.
+        """ Check that the code is a valid country code.
 
         We leave the data in its original format so that the Django model's
         CountryField can convert it to the internal representation used
         by the django-countries library.
+        :param dict data: Country code
+        :return: Valid country code
+        :rtype: dict
         """
 
         if not data:
@@ -40,25 +40,27 @@ class CustomCountryField(CountryField):
 
 
 class CustomLanguageField(serializers.Field):
-    """
-    Field to serialize a Language code.
-    """
+    """ Field to serialize a Language code. """
 
     LANGUAGE_CODES = dict(settings.ALL_LANGUAGES).keys()
 
-    def to_representation(self, obj):
+    def to_representation(self, value):
+        """ Represent the country as a 2-character unicode identifier.
+        :param (char) value: Field value
+        :return: Unicode representation of value
+        :rtype: unicode
         """
-        Represent the country as a 2-character unicode identifier.
-        """
-        return unicode(obj)
+        return unicode(value)
 
     def to_internal_value(self, data):
-        """
-        Check that the code is a valid language code.
+        """ Check that the code is a valid language code.
 
         We leave the data in its original format so that the Django model's
         CountryField can convert it to the internal representation used
         by the django-countries library.
+        :param dict data: Language code
+        :return: Valid language code
+        :rtype: dict
         """
 
         if not data:
@@ -74,11 +76,13 @@ class CustomLanguageField(serializers.Field):
 
 
 class CustomCourseTeamCreationSerializer(CourseTeamCreationSerializer):
+    """ Custom serializer for course team creation """
     country = CustomCountryField(required=True)
     language = CustomLanguageField(required=True)
 
 
 class CustomUserMembershipSerializer(UserMembershipSerializer):
+    """ Custom serializer for user membership inherittes from CourseTeamMembership"""
     class Meta(object):
         model = UserMembershipSerializer.Meta.model
         fields = UserMembershipSerializer.Meta.fields + (
@@ -90,17 +94,33 @@ class CustomUserMembershipSerializer(UserMembershipSerializer):
     last_activity_natural = serializers.SerializerMethodField()
     date_joined_natural = serializers.SerializerMethodField()
 
-    def get_profile_color(self, membership):
+    def get_profile_color(self, membership):  # pylint: disable=unused-argument
+        """ Get profile color
+        :param CourseTeamMembership membership: Course team membership model object
+        :return: Hex color code , i.e #FFFFFF
+        :rtype: string
+        """
         return generate_random_user_icon_color()
 
     def get_last_activity_natural(self, membership):
+        """ Get last activity time in human readable format i.e. a minute ago, 2 hours ago etc
+        :param CourseTeamMembership membership: Course team membership model object
+        :return: Natural date time
+        :rtype: string
+        """
         return naturaltime(membership.last_activity_at)
 
     def get_date_joined_natural(self, membership):
+        """ Get joined date time in human readable format i.e. a minute ago, 2 hours ago etc
+        :param CourseTeamMembership membership: Course team membership model object
+        :return: Natural date time
+        :rtype: string
+        """
         return naturaltime(membership.date_joined)
 
 
 class CustomCourseTeamSerializer(CourseTeamSerializer):
+    """ Custom serializer for course team """
     country = serializers.SerializerMethodField()
     language = serializers.SerializerMethodField()
     banner_color = serializers.SerializerMethodField()
@@ -112,14 +132,29 @@ class CustomCourseTeamSerializer(CourseTeamSerializer):
         read_only_fields = CourseTeamSerializer.Meta.read_only_fields
 
     def get_country(self, course_team):
+        """ Get course team banner country
+        :param CourseTeam course_team: Course team model object
+        :return: Country name
+        :rtype: string
+        """
         return course_team.country.name.format()
 
     def get_language(self, course_team):
+        """ Get valid corresponding language from settings otherwise return course team language
+        :param CourseTeam course_team: Course team model object
+        :return: Course team language
+        :rtype: list
+        """
         languages = dict(settings.ALL_LANGUAGES)
         try:
             return languages[course_team.language]
         except KeyError:
             return course_team.language
 
-    def get_banner_color(self, course_team):
+    def get_banner_color(self, course_team):  # pylint: disable=unused-argument
+        """ Get course team banner color
+        :param CourseTeam course_team: Course team model object
+        :return: Hex color code , i.e #FFFFFF
+        :rtype: string
+        """
         return generate_random_team_banner_color()

--- a/openedx/features/teams/serializers.py
+++ b/openedx/features/teams/serializers.py
@@ -1,10 +1,14 @@
 """Defines serializers used by the Team API."""
-from lms.djangoapps.teams.serializers import (
-    CourseTeamCreationSerializer, CountryField, CourseTeamSerializer, UserMembershipSerializer
-)
-from rest_framework import serializers
 from django.conf import settings
 from django.contrib.humanize.templatetags.humanize import naturaltime
+from rest_framework import serializers
+
+from lms.djangoapps.teams.serializers import (
+    CountryField,
+    CourseTeamCreationSerializer,
+    CourseTeamSerializer,
+    UserMembershipSerializer
+)
 
 from .helpers import generate_random_team_banner_color, generate_random_user_icon_color
 

--- a/openedx/features/teams/tests/factories.py
+++ b/openedx/features/teams/tests/factories.py
@@ -1,4 +1,6 @@
-""" Factories Required for testing teams module """
+"""
+Factories Required for testing teams module
+"""
 import factory
 from factory.django import DjangoModelFactory
 
@@ -10,14 +12,18 @@ TEAM_COUNTRY = 'US'
 
 
 class CourseTeamFactory(BaseCourseTeamFactory):
-    """ A custom CourseTeamFactory to generate "TeamGroupChat" along with "CourseTeam" object. """
+    """
+    A custom CourseTeamFactory to generate "TeamGroupChat" along with "CourseTeam" object.
+    """
 
     country = TEAM_COUNTRY
     language = TEAM_LANGUAGE
 
     @factory.post_generation
     def team_group_chat(self, create, expected, **kwargs):  # pylint: disable=unused-argument
-        """ Create a TeamGroupChat object for the created CourseTeam object
+        """
+        Create a TeamGroupChat object for the created CourseTeam object
+
         :class:`factory.declarations.PostGenerationDeclaration`
         """
         if create:
@@ -28,7 +34,9 @@ class CourseTeamFactory(BaseCourseTeamFactory):
 
 
 class TeamGroupChatFactory(DjangoModelFactory):
-    """ Factory for TeamGroupChat model. """
+    """
+    Factory for TeamGroupChat model
+    """
     class Meta(object):
         model = TeamGroupChat
         django_get_or_create = ('slug',)

--- a/openedx/features/teams/tests/factories.py
+++ b/openedx/features/teams/tests/factories.py
@@ -1,12 +1,9 @@
-"""
-    Factories Required for testing teams module
-"""
+""" Factories Required for testing teams module """
 import factory
 from factory.django import DjangoModelFactory
 
 from lms.djangoapps.teams.tests.factories import CourseTeamFactory as BaseCourseTeamFactory
 from nodebb.models import TeamGroupChat
-
 
 TEAM_LANGUAGE = 'en'
 TEAM_COUNTRY = 'US'
@@ -19,8 +16,10 @@ class CourseTeamFactory(BaseCourseTeamFactory):
     language = TEAM_LANGUAGE
 
     @factory.post_generation
-    def team_group_chat(self, create, expected, **kwargs):
-        """ Create a TeamGroupChat object for the created CourseTeam object"""
+    def team_group_chat(self, create, expected, **kwargs):  # pylint: disable=unused-argument
+        """ Create a TeamGroupChat object for the created CourseTeam object
+        :class:`factory.declarations.PostGenerationDeclaration`
+        """
         if create:
             self.save()
             return TeamGroupChatFactory.create(team=self, room_id=0, **kwargs)

--- a/openedx/features/teams/tests/test_helpers.py
+++ b/openedx/features/teams/tests/test_helpers.py
@@ -1,4 +1,6 @@
-"""All unit test for helpers in teams app"""
+"""
+All unit test for helpers in teams app
+"""
 import factory
 from django.conf import settings
 from django.db.models import signals
@@ -24,11 +26,15 @@ from xmodule.modulestore.tests.factories import CourseFactory
 USER_COUNTRY = 'US'
 
 class HelpersTestCase(ModuleStoreTestCase):
-    """ Tests for all helpers in teams module."""
+    """
+    Tests for all helpers in teams module.
+    """
 
     @factory.django.mute_signals(signals.pre_save, signals.post_save)
     def setUp(self):
-        """ Setup data required for the following test cases """
+        """
+        Setup data required for the following test cases
+        """
         super(HelpersTestCase, self).setUp()
         self.topics = self._create_topics()
         self.course = self._create_course()
@@ -36,14 +42,18 @@ class HelpersTestCase(ModuleStoreTestCase):
         self.user = UserFactory.create(profile__country=USER_COUNTRY)
 
     def _create_topics(self):
-        """Return dummy topics data"""
+        """
+        Return dummy topics data
+        """
         return [
             {u'name': u'Topic', u'description': u'The first best topic!', u'id': u'0', 'url': 'example.com/topic/0'},
             {u'name': u'Topic', u'description': u'The second best topic!', u'id': u'1', 'url': 'example.com/topic/1'},
         ]
 
     def _create_course(self):
-        """Create and return test course
+        """
+        Create and return test course
+
         :return Course: Course test data
         """
         org = 'edX'
@@ -64,8 +74,10 @@ class HelpersTestCase(ModuleStoreTestCase):
         return course
 
     def _create_team(self, course_id, topic_id):
-        """Create and return a CourseTeam for provided Course with provided course_id
+        """
+        Create and return a CourseTeam for provided Course with provided course_id
         and Topic with provided topic_id
+
         :param int course_id: Id of the course for which the team is to be generated
         :param int topic_id: Id of the topic for which the team is to be generated
         :return: Course team test data
@@ -80,17 +92,23 @@ class HelpersTestCase(ModuleStoreTestCase):
         return team
 
     def test_generate_random_user_icon_color(self):
-        """ Test that the icon color generated is from valid colors list. """
+        """
+        Test that the icon color generated is from valid colors list.
+        """
         color = generate_random_user_icon_color()
         self.assertIn(color, USER_ICON_COLORS)
 
     def test_generate_random_team_banner_color(self):
-        """ Test that the team banner color generated is from valid colors list. """
+        """
+        Test that the team banner color generated is from valid colors list.
+        """
         color = generate_random_team_banner_color()
         self.assertIn(color, TEAM_BANNER_COLORS)
 
     def test_make_embed_url_with_topic_url(self):
-        """ Test that correct embed url is generated when topic_url is provided and no team_group_chat is given"""
+        """
+        Test that correct embed url is generated when topic_url is provided and no team_group_chat is given
+        """
         embed_url = make_embed_url(team_group_chat=None, user=self.user, topic_url=self.topics[0]['url'])
         expected_output = '{}/embed/{}?iframe=embedView&isTopic=True'.format(
             settings.NODEBB_ENDPOINT,
@@ -99,14 +117,17 @@ class HelpersTestCase(ModuleStoreTestCase):
         self.assertEqual(embed_url, expected_output)
 
     def test_make_embed_url_with_team_group_chat(self):
-        """ Test that correct embed url is generated when no topic_url is provided but team_group_chat is given"""
+        """
+        Test that correct embed url is generated when no topic_url is provided but team_group_chat is given
+        """
         team_group_chat = self.team.team.all().first()
         embed_url = make_embed_url(team_group_chat=team_group_chat, user=self.user, topic_url=None)
         expected_output = '{}/category/{}?iframe=embedView'.format(settings.NODEBB_ENDPOINT, team_group_chat.slug)
         self.assertEqual(embed_url, expected_output)
 
     def test_make_embed_url_with_only_user(self):
-        """ Test that correct embed url is generated when no topic_url is provided and slug value for
+        """
+        Test that correct embed url is generated when no topic_url is provided and slug value for
         team_group_chat is empty
         """
         team_group_chat = self.team.team.all().first()
@@ -118,7 +139,8 @@ class HelpersTestCase(ModuleStoreTestCase):
         self.assertEqual(embed_url, expected_output)
 
     def test_serialize(self):
-        """ Test that a team object is serialized correctly with given request and context.
+        """
+        Test that a team object is serialized correctly with given request and context.
         Values of serialized data are compared with that of matching keys in actual data
         """
         data = self.team.__dict__
@@ -136,7 +158,8 @@ class HelpersTestCase(ModuleStoreTestCase):
         self.assertEqual(serialized_data, expected_data)
 
     def test_get_user_recommended_teams(self):
-        """ Test that the helper method returns user recommended teams bases on
+        """
+        Test that the helper method returns user recommended teams bases on
         user country. Teams in which user is enrolled should not be returned.
         """
         expected_result = [self.team, ]
@@ -144,17 +167,23 @@ class HelpersTestCase(ModuleStoreTestCase):
         self.assertEqual(actual_result, expected_result)
 
     def test_get_user_course_with_access(self):
-        """ Test that user can access the course """
+        """
+        Test that user can access the course
+        """
         result = get_user_course_with_access(self.course.id.__str__(), self.user)
         self.assertEqual(result, self.course)
 
     def test_get_team_topic_with_topic_id_provided(self):
-        """ Test that `get_team_topic` returns the topic with matching topic_id form
-        current course team topics """
+        """
+        Test that `get_team_topic` returns the topic with matching topic_id form
+        current course team topics
+        """
         result = get_team_topic(self.course, self.topics[0]['id'])
         self.assertEqual(result, self.topics[0])
 
     def test_get_team_topic_with_no_topic_id_provided(self):
-        """ Test that `get_team_topic` returns None if no topic_id is provided"""
+        """
+        Test that `get_team_topic` returns None if no topic_id is provided
+        """
         result = get_team_topic(self.course, None)
         self.assertEqual(result, None)

--- a/openedx/features/teams/tests/test_helpers.py
+++ b/openedx/features/teams/tests/test_helpers.py
@@ -1,3 +1,4 @@
+"""All unit test for helpers in teams app"""
 import factory
 from django.conf import settings
 from django.db.models import signals
@@ -22,7 +23,6 @@ from xmodule.modulestore.tests.factories import CourseFactory
 
 USER_COUNTRY = 'US'
 
-
 class HelpersTestCase(ModuleStoreTestCase):
     """ Tests for all helpers in teams module."""
 
@@ -36,14 +36,16 @@ class HelpersTestCase(ModuleStoreTestCase):
         self.user = UserFactory.create(profile__country=USER_COUNTRY)
 
     def _create_topics(self):
-        """ Return dummy topics data """
+        """Return dummy topics data"""
         return [
             {u'name': u'Topic', u'description': u'The first best topic!', u'id': u'0', 'url': 'example.com/topic/0'},
             {u'name': u'Topic', u'description': u'The second best topic!', u'id': u'1', 'url': 'example.com/topic/1'},
         ]
 
     def _create_course(self):
-        """ Create and return test course """
+        """Create and return test course
+        :return Course: Course test data
+        """
         org = 'edX'
         course_number = 'CS101'
         course_run = '2015_Q1'
@@ -62,15 +64,12 @@ class HelpersTestCase(ModuleStoreTestCase):
         return course
 
     def _create_team(self, course_id, topic_id):
-        """ Create and return a CourseTeam for provided Course with provided course_id
+        """Create and return a CourseTeam for provided Course with provided course_id
         and Topic with provided topic_id
-
-        Arguments:
-            course_id {int} -- Id of the course for which the team is to be generated
-            topic_id {int} --Id of the topic for which the team is to be generated
-
-        Returns:
-            CourseTeam
+        :param int course_id: Id of the course for which the team is to be generated
+        :param int topic_id: Id of the topic for which the team is to be generated
+        :return: Course team test data
+        :rtype: CourseTeam
         """
         team = CourseTeamFactory.create(
             course_id=course_id,
@@ -93,7 +92,10 @@ class HelpersTestCase(ModuleStoreTestCase):
     def test_make_embed_url_with_topic_url(self):
         """ Test that correct embed url is generated when topic_url is provided and no team_group_chat is given"""
         embed_url = make_embed_url(team_group_chat=None, user=self.user, topic_url=self.topics[0]['url'])
-        expected_output = '{}/embed/{}?iframe=embedView&isTopic=True'.format(settings.NODEBB_ENDPOINT, self.topics[0]['id'])
+        expected_output = '{}/embed/{}?iframe=embedView&isTopic=True'.format(
+            settings.NODEBB_ENDPOINT,
+            self.topics[0]['id']
+        )
         self.assertEqual(embed_url, expected_output)
 
     def test_make_embed_url_with_team_group_chat(self):

--- a/openedx/features/teams/tests/test_helpers.py
+++ b/openedx/features/teams/tests/test_helpers.py
@@ -1,27 +1,24 @@
 import factory
-
 from django.conf import settings
 from django.db.models import signals
 
 from lms.djangoapps.onboarding.tests.factories import UserFactory
-from xmodule.modulestore.tests.factories import CourseFactory
+from openedx.features.teams.helpers import (
+    TEAM_BANNER_COLORS,
+    USER_ICON_COLORS,
+    generate_random_team_banner_color,
+    generate_random_user_icon_color,
+    get_team_topic,
+    get_user_course_with_access,
+    get_user_recommended_team,
+    make_embed_url,
+    serialize
+)
+from openedx.features.teams.serializers import CustomCourseTeamCreationSerializer
+from openedx.features.teams.tests.factories import CourseTeamFactory
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-
-from openedx.features.teams.tests.factories import CourseTeamFactory
-from openedx.features.teams.serializers import CustomCourseTeamCreationSerializer
-from openedx.features.teams.helpers import (
-    USER_ICON_COLORS,
-    TEAM_BANNER_COLORS,
-    generate_random_user_icon_color,
-    generate_random_team_banner_color,
-    make_embed_url,
-    serialize,
-    get_user_recommended_team,
-    get_user_course_with_access,
-    get_team_topic
-)
-
+from xmodule.modulestore.tests.factories import CourseFactory
 
 USER_COUNTRY = 'US'
 

--- a/openedx/features/teams/tests/test_serializers.py
+++ b/openedx/features/teams/tests/test_serializers.py
@@ -1,3 +1,4 @@
+""" Test class for teams serializer """
 import factory
 from django.conf import settings
 from django.contrib.humanize.templatetags.humanize import naturaltime

--- a/openedx/features/teams/tests/test_serializers.py
+++ b/openedx/features/teams/tests/test_serializers.py
@@ -1,4 +1,6 @@
-""" Test class for teams serializer """
+"""
+Test class for teams serializer
+"""
 import factory
 from django.conf import settings
 from django.contrib.humanize.templatetags.humanize import naturaltime
@@ -28,11 +30,15 @@ INVALID_LANGUAGE_CODE = '{language_code} is not a valid language code'
 
 
 class SerializersTestBaseClass(ModuleStoreTestCase):
-    """ Base class for common steps required for testing serializers """
+    """
+    Base class for common steps required for testing serializers
+    """
 
     @factory.django.mute_signals(signals.pre_save, signals.post_save)
     def setUp(self):
-        """ create required data for testing serializers in the module """
+        """
+        create required data for testing serializers in the module
+        """
         super(SerializersTestBaseClass, self).setUp()
         org = 'edX'
         course_number = 'CS101'
@@ -60,7 +66,9 @@ class SerializersTestBaseClass(ModuleStoreTestCase):
 
 
 class CreateTeamsSerializerTestCase(SerializersTestBaseClass):
-    """ Tests for the create team serializer."""
+    """
+    Tests for the create team serializer.
+    """
 
     def _get_team_dict_data(self):
         data = self.team.__dict__
@@ -68,7 +76,9 @@ class CreateTeamsSerializerTestCase(SerializersTestBaseClass):
         return data
 
     def test_case_create_team__with_empty_language_field(self):
-        """ Test that correct error message is thrown when serializing team with empty language field"""
+        """
+        Test that correct error message is thrown when serializing team with empty language field
+        """
         self.team.country = VALID_COUNTRY
         data = self._get_team_dict_data()
         expected_result = {'language': REQUIRED_ERROR_MSG['LANGUAGE']}
@@ -77,7 +87,9 @@ class CreateTeamsSerializerTestCase(SerializersTestBaseClass):
         self.assertEqual(serialized_data.errors, expected_result)
 
     def test_case_create_team_with_invalid_language_code(self):
-        """ Test that correct error message is thrown when serializing team with invalid language value"""
+        """
+        Test that correct error message is thrown when serializing team with invalid language value
+        """
         self.team.country = VALID_COUNTRY
         self.team.language = INVALID_LANGUAGE
         data = self._get_team_dict_data()
@@ -87,7 +99,9 @@ class CreateTeamsSerializerTestCase(SerializersTestBaseClass):
         self.assertEqual(serialized_data.errors, expected_result)
 
     def test_case_create_team_with_empty_country_field(self):
-        """ Test that correct error message is thrown when serializing team with empty country field"""
+        """
+        Test that correct error message is thrown when serializing team with empty country field
+        """
         self.team.language = VALID_LANGUAGE
         data = self._get_team_dict_data()
         expected_result = {'country': REQUIRED_ERROR_MSG['COUNTRY']}
@@ -96,7 +110,9 @@ class CreateTeamsSerializerTestCase(SerializersTestBaseClass):
         self.assertEqual(serialized_data.errors, expected_result)
 
     def test_case_create_team_with_invalid_country_code(self):
-        """ Test that correct error message is thrown when serializing team with invalid country value"""
+        """
+        Test that correct error message is thrown when serializing team with invalid country value
+        """
         self.team.country = INVALID_COUNTRY
         self.team.language = VALID_LANGUAGE
         data = self._get_team_dict_data()
@@ -106,7 +122,8 @@ class CreateTeamsSerializerTestCase(SerializersTestBaseClass):
         self.assertEqual(serialized_data.errors, expected_result)
 
     def test_case_create_team_with_empty_language_and_country_fields(self):
-        """ Test that correct error message is thrown when serializing team with both empty language field
+        """
+        Test that correct error message is thrown when serializing team with both empty language field
         and empty country field
         """
         data = self._get_team_dict_data()
@@ -116,7 +133,8 @@ class CreateTeamsSerializerTestCase(SerializersTestBaseClass):
         self.assertEqual(serialized_data.errors, expected_result)
 
     def test_case_create_team_with_invalid_language_and_country_fields(self):
-        """ Test that correct error message is thrown when serializing team with both invalid language field
+        """
+        Test that correct error message is thrown when serializing team with both invalid language field
         and invalid country field
         """
         self.team.country = INVALID_COUNTRY
@@ -129,7 +147,9 @@ class CreateTeamsSerializerTestCase(SerializersTestBaseClass):
         self.assertEqual(serialized_data.errors, expected_result)
 
     def test_case_create_team_with_valid_language_and_country_fields(self):
-        """ Test that no errors are returned when team has valid language and country values """
+        """
+        Test that no errors are returned when team has valid language and country values
+        """
         self.team.country = VALID_COUNTRY
         self.team.language = VALID_LANGUAGE
         data = self._get_team_dict_data()
@@ -139,7 +159,9 @@ class CreateTeamsSerializerTestCase(SerializersTestBaseClass):
         self.assertEqual(serialized_data.errors, expected_result)
 
     def test_case_valid_language_representation(self):
-        """ Test that after serializing team object language is represented correctly in unicode"""
+        """
+        Test that after serializing team object language is represented correctly in unicode
+        """
         self.team.country = VALID_COUNTRY
         self.team.language = VALID_LANGUAGE
         data = self._get_team_dict_data()
@@ -150,11 +172,14 @@ class CreateTeamsSerializerTestCase(SerializersTestBaseClass):
 
 
 class CustomUserMembershipSerializerTestCase(SerializersTestBaseClass):
-    """ Test cases for CustomUserMembershipSerializer """
+    """
+    Test cases for CustomUserMembershipSerializer
+    """
 
     @factory.django.mute_signals(signals.pre_save, signals.post_save)
     def setUp(self):
-        """ Create required data for testing CustomUserMembershipSerializer.
+        """
+        Create required data for testing CustomUserMembershipSerializer.
         create a new user and join that user in the testing team.
         """
         super(CustomUserMembershipSerializerTestCase, self).setUp()
@@ -162,7 +187,9 @@ class CustomUserMembershipSerializerTestCase(SerializersTestBaseClass):
         self.membership = CourseTeamMembershipFactory.create(team=self.team, user=self.user)
 
     def test_case_validate_profile_color(self):
-        """ Test that correct color is stored in serialized data"""
+        """
+        Test that correct color is stored in serialized data
+        """
         data = CustomUserMembershipSerializer(self.membership, context={
             'expand': [u'team', u'user'],
             'request': RequestFactory().get('/api/team/v0/team_membership')
@@ -170,7 +197,9 @@ class CustomUserMembershipSerializerTestCase(SerializersTestBaseClass):
         self.assertIn(data['profile_color'], USER_ICON_COLORS)
 
     def test_case_validate_natural_last_activity(self):
-        """ Test that last_activity is stored in valid natural format after serializing the data"""
+        """
+        Test that last_activity is stored in valid natural format after serializing the data
+        """
         data = CustomUserMembershipSerializer(self.membership, context={
             'expand': [u'team', u'user'],
             'request': RequestFactory().get('/api/team/v0/team_membership')
@@ -178,7 +207,9 @@ class CustomUserMembershipSerializerTestCase(SerializersTestBaseClass):
         self.assertEqual(data['last_activity_natural'], naturaltime(self.membership.last_activity_at))
 
     def test_case_validate_natural_date_joined(self):
-        """ Test that date_joined is stored in valid natural format after serializing the data"""
+        """
+        Test that date_joined is stored in valid natural format after serializing the data
+        """
         data = CustomUserMembershipSerializer(self.membership, context={
             'expand': [u'team', u'user'],
             'request': RequestFactory().get('/api/team/v0/team_membership')
@@ -187,10 +218,14 @@ class CustomUserMembershipSerializerTestCase(SerializersTestBaseClass):
 
 
 class CustomCourseTeamSerializerTestCase(SerializersTestBaseClass):
-    """ Test cases for CustomCourseTeamSerializer """
+    """
+    Test cases for CustomCourseTeamSerializer
+    """
 
     def test_case_validate_team_country(self):
-        """ Test that formatted(full) country name is stored in serialized data"""
+        """
+        Test that formatted(full) country name is stored in serialized data
+        """
         self.team.country = VALID_COUNTRY
         data = CustomCourseTeamSerializer(self.team, context={
             'request': RequestFactory().get('/api/team/v0/team_membership')
@@ -198,7 +233,9 @@ class CustomCourseTeamSerializerTestCase(SerializersTestBaseClass):
         self.assertEqual(data['country'], self.team.country.name.format())
 
     def test_case_validate_team_language(self):
-        """ Test that formatted(full) language name is stored in serialized data"""
+        """
+        Test that formatted(full) language name is stored in serialized data
+        """
         self.team.language = VALID_LANGUAGE
         data = CustomCourseTeamSerializer(self.team, context={
             'request': RequestFactory().get('/api/team/v0/team_membership')
@@ -207,7 +244,8 @@ class CustomCourseTeamSerializerTestCase(SerializersTestBaseClass):
         self.assertEqual(data['language'], languages[self.team.language])
 
     def test_case_team_with_invalid_language(self):
-        """ Test that language name is stored as it is if the given language code does not exist in valid
+        """
+        Test that language name is stored as it is if the given language code does not exist in valid
         languages list
         """
         self.team.language = INVALID_LANGUAGE
@@ -217,7 +255,9 @@ class CustomCourseTeamSerializerTestCase(SerializersTestBaseClass):
         self.assertEqual(data['language'], self.team.language)
 
     def test_case_validate_team_banner_color(self):
-        """ Test that valid team banner color is stored in serialized data """
+        """
+        Test that valid team banner color is stored in serialized data
+        """
         data = CustomCourseTeamSerializer(self.team, context={
             'request': RequestFactory().get('/api/team/v0/team_membership')
         }).data

--- a/openedx/features/teams/tests/test_serializers.py
+++ b/openedx/features/teams/tests/test_serializers.py
@@ -1,27 +1,20 @@
 import factory
-
-from django.db.models import signals
 from django.conf import settings
-from django.test.client import RequestFactory
 from django.contrib.humanize.templatetags.humanize import naturaltime
+from django.db.models import signals
+from django.test.client import RequestFactory
 
-from lms.djangoapps.teams.tests.factories import CourseTeamFactory
-from lms.djangoapps.teams.tests.factories import CourseTeamMembershipFactory
 from lms.djangoapps.onboarding.tests.factories import UserFactory
-from xmodule.modulestore.tests.factories import CourseFactory
-from xmodule.modulestore import ModuleStoreEnum
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-
+from lms.djangoapps.teams.tests.factories import CourseTeamFactory, CourseTeamMembershipFactory
+from openedx.features.teams.helpers import TEAM_BANNER_COLORS, USER_ICON_COLORS
 from openedx.features.teams.serializers import (
     CustomCourseTeamCreationSerializer,
-    CustomUserMembershipSerializer,
-    CustomCourseTeamSerializer
+    CustomCourseTeamSerializer,
+    CustomUserMembershipSerializer
 )
-from openedx.features.teams.helpers import (
-    USER_ICON_COLORS,
-    TEAM_BANNER_COLORS,
-)
-
+from xmodule.modulestore import ModuleStoreEnum
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory
 
 VALID_COUNTRY = 'LA'
 VALID_LANGUAGE = 'kl'

--- a/openedx/features/teams/tests/test_views.py
+++ b/openedx/features/teams/tests/test_views.py
@@ -1,3 +1,4 @@
+""" All tests for teams application views"""
 import urllib
 
 import factory
@@ -45,7 +46,7 @@ class TeamsTestsBaseClass(ModuleStoreTestCase):
         self.course = self._create_course()
 
         self.teams = []
-        for i in range(TOTAL_TEAMS):
+        for _ in range(TOTAL_TEAMS):
             self.teams.append(self._create_team(self.course.id, topic_id=self.course.teams_topics[0]['id']))
 
         self.user = self._create_user()
@@ -78,12 +79,7 @@ class TeamsTestsBaseClass(ModuleStoreTestCase):
 
     @factory.django.mute_signals(signals.pre_save, signals.post_save)
     def _create_team(self, course_id, topic_id):
-        """ Create a CourseTeam for provided course_id and topic_id
-
-        Arguments:
-            course_id {int} -- id of the course for which the team is to be created
-            topic_id {int} -- id of the topic for which the team is to be created
-        """
+        """ Create a CourseTeam for provided course_id and topic_id """
         team = CourseTeamFactory.create(
             course_id=course_id,
             topic_id=topic_id,
@@ -94,42 +90,19 @@ class TeamsTestsBaseClass(ModuleStoreTestCase):
 
     @factory.django.mute_signals(signals.pre_save, signals.post_save)
     def _create_user(self, username=TEST_USERNAME, password=TEST_PASSWORD, **kwargs):
-        """ Create a User for provided username and password.
-
-        Arguments:
-            username {string} -- username for the user
-            password {string} -- password for the user
-            kwargs {dict} -- any additional attributes for the user
-        """
+        """ Create a User for provided username and password """
         user = UserFactory.create(username=username, password=password, **kwargs)
         return user
 
     @factory.django.mute_signals(signals.pre_save, signals.post_save)
     def _create_team_membership(self, team, user):
-        """Create a team membership object that is responsible for joining of a user in a team.
-
-        Arguments:
-            team {CourseTeam} -- Team to join
-            user {User} -- User who is going to join the team
-
-        Returns:
-            CourseTeamMembership
-        """
+        """Create a team membership object that is responsible for joining of a user in a team """
         membership = CourseTeamMembershipFactory.create(team=team, user=user)
         return membership
 
     @factory.django.mute_signals(signals.pre_save, signals.post_save)
     def _enroll_user_in_course(self, user, course_id):
-        """Enroll a user in a course
-
-
-        Arguments:
-            user {User} -- User who is going to be enrolled in a course
-            course_id {int} -- Id of the course in which to enroll the user
-
-        Returns:
-            CourseEnrollment
-        """
+        """Enroll a user in a course """
         enrollment = CourseEnrollmentFactory(user=user, course_id=course_id)
         return enrollment
 
@@ -210,7 +183,7 @@ class BrowseTeamsTestCase(TeamsTestsBaseClass):
         """
         client = Client()
         staff_user = self._create_user(username='staff_test_user', is_staff=True)
-        enrolled_user = self._enroll_user_in_course(user=staff_user, course_id=self.course.id)
+        self._enroll_user_in_course(user=staff_user, course_id=self.course.id)
         client.login(username=staff_user.username, password=TEST_PASSWORD)
 
         response = client.get(self.url)

--- a/openedx/features/teams/tests/test_views.py
+++ b/openedx/features/teams/tests/test_views.py
@@ -1,23 +1,22 @@
 import urllib
 
-import mock
 import factory
-from pyquery import PyQuery
+import mock
 from django.conf import settings
-from django.db.models import signals
 from django.core.urlresolvers import reverse
+from django.db.models import signals
 from django.test.client import Client
+from pyquery import PyQuery
 from w3lib.url import add_or_replace_parameter
 
-from openedx.core.djangolib.testing.philu_utils import configure_philu_theme
-from lms.djangoapps.teams.tests.factories import CourseTeamMembershipFactory
 from lms.djangoapps.onboarding.tests.factories import UserFactory
+from lms.djangoapps.teams.tests.factories import CourseTeamMembershipFactory
+from openedx.core.djangolib.testing.philu_utils import configure_philu_theme
+from openedx.features.teams.tests.factories import CourseTeamFactory
 from student.tests.factories import CourseEnrollmentFactory
-from xmodule.modulestore.tests.factories import CourseFactory
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-
-from openedx.features.teams.tests.factories import CourseTeamFactory
+from xmodule.modulestore.tests.factories import CourseFactory
 
 TOTAL_TEAMS = 3
 TOTAL_TOPICS = 1

--- a/openedx/features/teams/tests/test_views.py
+++ b/openedx/features/teams/tests/test_views.py
@@ -1,4 +1,6 @@
-""" All tests for teams application views"""
+"""
+All tests for teams application views
+"""
 import urllib
 
 import factory
@@ -31,16 +33,22 @@ TEST_PASSWORD = 'test_password'
 
 
 class TeamsTestsBaseClass(ModuleStoreTestCase):
-    """Base class for all test cases of "Teams" module."""
+    """
+    Base class for all test cases of `Teams` module.
+    """
 
     @classmethod
     def setUpClass(cls):
-        """ Setup "philu" theme for testing. Required for testing templates that exist in the theme ."""
+        """
+        Setup `philu` theme for testing. Required for testing templates that exist in the theme
+        """
         super(TeamsTestsBaseClass, cls).setUpClass()
         configure_philu_theme()
 
     def setUp(self):
-        """Setup all test data required for testing any of the test cases. """
+        """
+        Setup all test data required for testing any of the test cases.
+        """
         super(TeamsTestsBaseClass, self).setUp()
         self.topic = self._create_topic()
         self.course = self._create_course()
@@ -53,13 +61,17 @@ class TeamsTestsBaseClass(ModuleStoreTestCase):
         self.team_membership = self._create_team_membership(self.teams[0], self.user)
 
     def _create_topic(self):
-        """ Return a topic dict. """
+        """
+        Return a topic dict.
+        """
         topic = {u'name': u'T0pic', u'description': u'The best topic!', u'id': u'0', 'url': 'example.com/topic/0'}
         return topic
 
     @factory.django.mute_signals(signals.pre_save, signals.post_save)
     def _create_course(self, **kwargs):
-        """ Create and return a course with test data """
+        """
+        Create and return a course with test data
+        """
         org = kwargs.get('org') or 'edX'
         course_number = kwargs.get('course_number') or 'CS101'
         course_run = kwargs.get('course_run') or '2015_Q1'
@@ -79,7 +91,9 @@ class TeamsTestsBaseClass(ModuleStoreTestCase):
 
     @factory.django.mute_signals(signals.pre_save, signals.post_save)
     def _create_team(self, course_id, topic_id):
-        """ Create a CourseTeam for provided course_id and topic_id """
+        """
+        Create a CourseTeam for provided course_id and topic_id
+        """
         team = CourseTeamFactory.create(
             course_id=course_id,
             topic_id=topic_id,
@@ -90,35 +104,47 @@ class TeamsTestsBaseClass(ModuleStoreTestCase):
 
     @factory.django.mute_signals(signals.pre_save, signals.post_save)
     def _create_user(self, username=TEST_USERNAME, password=TEST_PASSWORD, **kwargs):
-        """ Create a User for provided username and password """
+        """
+        Create a User for provided username and password
+        """
         user = UserFactory.create(username=username, password=password, **kwargs)
         return user
 
     @factory.django.mute_signals(signals.pre_save, signals.post_save)
     def _create_team_membership(self, team, user):
-        """Create a team membership object that is responsible for joining of a user in a team """
+        """
+        Create a team membership object that is responsible for joining of a user in a team
+        """
         membership = CourseTeamMembershipFactory.create(team=team, user=user)
         return membership
 
     @factory.django.mute_signals(signals.pre_save, signals.post_save)
     def _enroll_user_in_course(self, user, course_id):
-        """Enroll a user in a course """
+        """
+        Enroll a user in a course
+        """
         enrollment = CourseEnrollmentFactory(user=user, course_id=course_id)
         return enrollment
 
 
 class BrowseTeamsTestCase(TeamsTestsBaseClass):
-    """Test cases for browse_teams view."""
+    """
+    Test cases for browse_teams view.
+    """
 
     def setUp(self):
-        """ Initiate the test data which is required in more than one of the test cases. """
+        """
+        Initiate the test data which is required in more than one of the test cases.
+        """
         super(BrowseTeamsTestCase, self).setUp()
         self.topic_link_selector = 'a.other-continents-widget'
         self.expexted_teams_count_text = '{} TEAMS'.format(TOTAL_TEAMS)
         self.url = reverse('teams_dashboard', args=[self.course.id])
 
     def test_anonymous_client_is_redirected(self):
-        """Verifies that an anonymous client cannot access the team dashboard, and is redirected to the login page."""
+        """
+        Verifies that an anonymous client cannot access the team dashboard, and is redirected to the login page.
+        """
         anonymous_client = Client()
         response = anonymous_client.get(self.url)
         redirect_url = '{0}?next={1}'.format(settings.LOGIN_URL, urllib.quote(self.url))
@@ -127,7 +153,9 @@ class BrowseTeamsTestCase(TeamsTestsBaseClass):
 
     @mock.patch.dict("django.conf.settings.FEATURES", {'ENABLE_TEAMS': False})
     def test_404_case_teams_feature_is_disabled(self):
-        """Test that 404 is returned when team feature is disabled."""
+        """
+        Test that 404 is returned when team feature is disabled.
+        """
 
         client = Client()
         client.login(username=self.user.username, password=TEST_PASSWORD)
@@ -136,7 +164,9 @@ class BrowseTeamsTestCase(TeamsTestsBaseClass):
         self.assertEqual(response.url, '404/')
 
     def test_404_case_user_not_enrolled_not_staff(self):
-        """Test that 404 is returned if the user is neither enrolled in course nor a staff member."""
+        """
+        Test that 404 is returned if the user is neither enrolled in course nor a staff member.
+        """
         client = Client()
         client.login(username=self.user.username, password=TEST_PASSWORD)
         response = client.get(self.url, follow=False)
@@ -144,7 +174,9 @@ class BrowseTeamsTestCase(TeamsTestsBaseClass):
         self.assertEqual(response.url, '404/')
 
     def test_case_user_is_not_enrolled_staff(self):
-        """Test that valid data is rendered if user is not enrolled in a course but is a staff member."""
+        """
+        Test that valid data is rendered if user is not enrolled in a course but is a staff member.
+        """
         client = Client()
         staff_user = self._create_user(username='staff_test_user', is_staff=True)
         client.login(username=staff_user.username, password=TEST_PASSWORD)
@@ -160,7 +192,8 @@ class BrowseTeamsTestCase(TeamsTestsBaseClass):
         self.assertTrue(teams_count_per_topic_exists)
 
     def test_case_user_is_enrolled_not_staff(self):
-        """Test that correct number of topics and teams are rendered if user is enrolled in a course but
+        """
+        Test that correct number of topics and teams are rendered if user is enrolled in a course but
         is not a staff member.
         """
         client = Client()
@@ -178,7 +211,8 @@ class BrowseTeamsTestCase(TeamsTestsBaseClass):
         self.assertTrue(teams_count_per_topic_exists)
 
     def test_case_user_is_enrolled_and_staff(self):
-        """Test that correct number of topics and teams are rendered if user is enrolled in a course and
+        """
+        Test that correct number of topics and teams are rendered if user is enrolled in a course and
         is a staff member too.
         """
         client = Client()
@@ -198,14 +232,17 @@ class BrowseTeamsTestCase(TeamsTestsBaseClass):
 
 
 class BrowseTopicTeamsTestCase(TeamsTestsBaseClass):
-    """Test cases for browse_topic_teams view."""
+    """
+    Test cases for browse_topic_teams view.
+    """
 
     def setUp(self):
         super(BrowseTopicTeamsTestCase, self).setUp()
         self.url = reverse('browse_topic_teams', args=[self.course.id, self.topic['id']])
 
     def test_anonymous_client_is_redirected(self):
-        """Verifies that an anonymous client cannot access the edit_team_memberships view, and is redirected
+        """
+        Verifies that an anonymous client cannot access the edit_team_memberships view, and is redirected
         to the login page.
         """
         anonymous_client = Client()
@@ -229,7 +266,9 @@ class BrowseTopicTeamsTestCase(TeamsTestsBaseClass):
         self.assertRedirects(response, redirect_url, target_status_code=302)
 
     def test_404_case_provide_invalid_topic_id(self):
-        """Test that 404 is returned when invalid topic_id is provided."""
+        """
+        Test that 404 is returned when invalid topic_id is provided.
+        """
         client = Client()
         client.login(username=self.user.username, password=TEST_PASSWORD)
         invalid_topic_teams_url = reverse('browse_topic_teams', args=[self.course.id, INVALID_TOPIC_PATTERN])
@@ -238,7 +277,9 @@ class BrowseTopicTeamsTestCase(TeamsTestsBaseClass):
         self.assertEqual(response.status_code, 404)
 
     def test_case_browse_valid_topic_id_teams(self):
-        """Test that correct number of teams are displayed when correct topic_id is provided."""
+        """
+        Test that correct number of teams are displayed when correct topic_id is provided.
+        """
         client = Client()
         client.login(username=self.user.username, password=TEST_PASSWORD)
 
@@ -252,14 +293,17 @@ class BrowseTopicTeamsTestCase(TeamsTestsBaseClass):
 
 
 class CreateTeamTestCase(TeamsTestsBaseClass):
-    """Test cases for create_team view."""
+    """
+    Test cases for create_team view.
+    """
 
     def setUp(self):
         super(CreateTeamTestCase, self).setUp()
         self.url = reverse('create_team', args=[self.course.id, self.topic['id']])
 
     def test_anonymous_client_is_redirected(self):
-        """Verifies that an anonymous client cannot access the create team page, and is redirected
+        """
+        Verifies that an anonymous client cannot access the create team page, and is redirected
         to the login page.
         """
         anonymous_client = Client()
@@ -283,7 +327,9 @@ class CreateTeamTestCase(TeamsTestsBaseClass):
         self.assertRedirects(response, redirect_url, target_status_code=302)
 
     def test_404_case_provide_invalid_topic(self):
-        """Test that 404 is returned when invalid topic_id is provided"""
+        """
+        Test that 404 is returned when invalid topic_id is provided
+        """
         client = Client()
         client.login(username=self.user.username, password=TEST_PASSWORD)
         invalid_team_create_url = reverse('create_team', args=[self.course.id, INVALID_TOPIC_ID])
@@ -293,7 +339,8 @@ class CreateTeamTestCase(TeamsTestsBaseClass):
 
     @factory.django.mute_signals(signals.post_delete)
     def test_case_create_team_when_user_is_not_joined_in_team(self):
-        """Test that "Create Team" header for form is displayed if user is not already a member of
+        """
+        Test that "Create Team" header for form is displayed if user is not already a member of
         any team of the course.
         """
         client = Client()
@@ -309,7 +356,8 @@ class CreateTeamTestCase(TeamsTestsBaseClass):
         self.assertTrue(is_create_team_header_exists)
 
     def test_case_create_team_when_user_has_already_joined_a_team(self):
-        """Test that correct informational message is displayed instead of create team form  if user is already
+        """
+        Test that correct informational message is displayed instead of create team form  if user is already
         a member of any team of the course.
         """
         client = Client()
@@ -326,7 +374,9 @@ class CreateTeamTestCase(TeamsTestsBaseClass):
 
 
 class MyTeamTestCase(TeamsTestsBaseClass):
-    """Test cases for my_teams view."""
+    """
+    Test cases for my_teams view.
+    """
 
     def setUp(self):
         super(MyTeamTestCase, self).setUp()
@@ -347,7 +397,8 @@ class MyTeamTestCase(TeamsTestsBaseClass):
         self.assertRedirects(response, redirect_url, target_status_code=302)
 
     def test_anonymous_client_is_redirected(self):
-        """Verifies that an anonymous client cannot access the "my teams" page, and is redirected
+        """
+        Verifies that an anonymous client cannot access the "my teams" page, and is redirected
         to the login page.
         """
         anonymous_client = Client()
@@ -356,7 +407,9 @@ class MyTeamTestCase(TeamsTestsBaseClass):
         self.assertRedirects(response, redirect_url)
 
     def test_case_no_course_team_exists(self):
-        """Test the error response when there is no team for given course id."""
+        """
+        Test the error response when there is no team for given course id.
+        """
         error_msg_selector = '.teams-content .box-widget p'
         expected_error_msg = 'You are not currently a member of any team.'
         client = Client()
@@ -371,7 +424,8 @@ class MyTeamTestCase(TeamsTestsBaseClass):
         self.assertIn(expected_error_msg, error_msg)
 
     def test_case_course_team_exists_and_no_topic_url_is_provided(self):
-        """Test that user is redirected to view_team without the topic_url when course team exists and there is no
+        """
+        Test that user is redirected to view_team without the topic_url when course team exists and there is no
         topic_url provided with the request
         """
         client = Client()
@@ -382,7 +436,8 @@ class MyTeamTestCase(TeamsTestsBaseClass):
         self.assertRedirects(response, redirect_url)
 
     def test_case_course_team_exists_and_topic_url_is_provided(self):
-        """Test that user is redirected to view_team with topic_url when course team exists and there is no
+        """
+        Test that user is redirected to view_team with topic_url when course team exists and there is no
         topic_url provided with the request
         """
         client = Client()
@@ -397,14 +452,18 @@ class MyTeamTestCase(TeamsTestsBaseClass):
 
 
 class ViewTeamTestCase(TeamsTestsBaseClass):
-    """Test cases for view_team view."""
+    """
+    Test cases for view_team view.
+    """
 
     def setUp(self):
         super(ViewTeamTestCase, self).setUp()
         self.url = reverse('view_team', args=[self.course.id, self.teams[0].team_id])
 
     def test_anonymous_client_is_redirected(self):
-        """Verifies that an anonymous client cannot view any team and is redirected to the login page."""
+        """
+        Verifies that an anonymous client cannot view any team and is redirected to the login page.
+        """
         anonymous_client = Client()
         response = anonymous_client.get(self.url)
         redirect_url = '{0}?next={1}'.format(settings.LOGIN_URL, urllib.quote(self.url))
@@ -426,7 +485,9 @@ class ViewTeamTestCase(TeamsTestsBaseClass):
         self.assertRedirects(response, redirect_url, target_status_code=302)
 
     def test_404_case_no_team_exists_for_provided_team_id(self):
-        """Test that 404 is returned when there is no team with provided team id."""
+        """
+        Test that 404 is returned when there is no team with provided team id.
+        """
         client = Client()
         url = reverse('view_team', args=[self.course.id, NONE_EXISTING_TEAM_ID])
         client.login(username=self.user.username, password=TEST_PASSWORD)
@@ -435,7 +496,9 @@ class ViewTeamTestCase(TeamsTestsBaseClass):
         self.assertEqual(response.status_code, 404)
 
     def test_404_case_team_exists_but_no_team_group_chat_exists_for_provided_team_id(self):
-        """Test that 404 is returned when there is no team_group_chat for team with provided team id."""
+        """
+        Test that 404 is returned when there is no team_group_chat for team with provided team id.
+        """
         client = Client()
         team_without_group_chat = self._create_team(self.course.id, self.course.teams_topics[0]['id'])
         team_without_group_chat.team.all().delete()
@@ -446,7 +509,8 @@ class ViewTeamTestCase(TeamsTestsBaseClass):
         self.assertEqual(response.status_code, 404)
 
     def test_case_team_and_team_group_chat_exist_for_provided_team_id(self):
-        """Test that iframe for team group chat exists and "Edit Membership" button does not exist (which
+        """
+        Test that iframe for team group chat exists and "Edit Membership" button does not exist (which
         only exists for administrator of the team) when Team and TeamGroupChat exists for provided team_id.
         """
         team_edit_button_selector = 'action-edit-team'
@@ -466,14 +530,17 @@ class ViewTeamTestCase(TeamsTestsBaseClass):
 
 
 class UpdateTeamTestCase(TeamsTestsBaseClass):
-    """Test cases for update_team view."""
+    """
+    Test cases for update_team view.
+    """
 
     def setUp(self):
         super(UpdateTeamTestCase, self).setUp()
         self.url = reverse('update_team', args=[self.course.id, self.teams[0].team_id])
 
     def test_anonymous_client_is_redirected(self):
-        """Verifies that an anonymous client cannot access the update_team view, and is redirected to
+        """
+        Verifies that an anonymous client cannot access the update_team view, and is redirected to
         the login page.
         """
         anonymous_client = Client()
@@ -497,7 +564,9 @@ class UpdateTeamTestCase(TeamsTestsBaseClass):
         self.assertRedirects(response, redirect_url, target_status_code=302)
 
     def test_404_case_user_is_not_staff(self):
-        """Test that 404 is returned when current user is not staff member."""
+        """
+        Test that 404 is returned when current user is not staff member.
+        """
         client = Client()
         client.login(username=self.user.username, password=TEST_PASSWORD)
         response = client.get(self.url, follow=True)
@@ -505,7 +574,9 @@ class UpdateTeamTestCase(TeamsTestsBaseClass):
         self.assertEqual(response.status_code, 404)
 
     def test_404_case_user_is_staff_but_no_team_exists_for_provided_team_id(self):
-        """Test that 404 is returned when current user is staff but there is no team with provided team id."""
+        """
+        Test that 404 is returned when current user is staff but there is no team with provided team id.
+        """
         client = Client()
         staff_user = self._create_user(username='staff_test_user', is_staff=True)
         client.login(username=staff_user.username, password=TEST_PASSWORD)
@@ -515,7 +586,8 @@ class UpdateTeamTestCase(TeamsTestsBaseClass):
         self.assertEqual(response.status_code, 404)
 
     def test_case_user_is_staff_and_team_exists_for_provided_team_id(self):
-        """Test that "Edit Membership" and "Update Team" form buttons are displayed when current user is staff
+        """
+        Test that "Edit Membership" and "Update Team" form buttons are displayed when current user is staff
         and there is existing team for provided team_id
         """
         edit_membership_button_selector = '.action-edit-members'
@@ -537,14 +609,17 @@ class UpdateTeamTestCase(TeamsTestsBaseClass):
 
 
 class EditTeamMembershitTestCase(TeamsTestsBaseClass):
-    """Test cases for edit_team_memberships view."""
+    """
+    Test cases for edit_team_memberships view.
+    """
 
     def setUp(self):
         super(EditTeamMembershitTestCase, self).setUp()
         self.url = reverse('edit_team_memberships', args=[self.course.id, self.teams[0].team_id])
 
     def test_anonymous_client_is_redirected(self):
-        """Verifies that an anonymous client cannot access the edit_team_memberships view, and is redirected
+        """
+        Verifies that an anonymous client cannot access the edit_team_memberships view, and is redirected
         to the login page.
         """
         anonymous_client = Client()
@@ -568,7 +643,9 @@ class EditTeamMembershitTestCase(TeamsTestsBaseClass):
         self.assertRedirects(response, redirect_url, target_status_code=302)
 
     def test_404_case_user_is_not_staff(self):
-        """Test that 404 is returned when current user is not a staff member"""
+        """
+        Test that 404 is returned when current user is not a staff member
+        """
         client = Client()
         client.login(username=self.user.username, password=TEST_PASSWORD)
         response = client.get(self.url, follow=True)
@@ -576,7 +653,9 @@ class EditTeamMembershitTestCase(TeamsTestsBaseClass):
         self.assertEqual(response.status_code, 404)
 
     def test_404_case_user_is_staff_but_no_team_exists_for_provided_team_id(self):
-        """Test that 404 is returned when current user is staff user but there is no team with provided team id."""
+        """
+        Test that 404 is returned when current user is staff user but there is no team with provided team id.
+        """
         client = Client()
         staff_user = self._create_user(username='staff_test_user', is_staff=True)
         client.login(username=staff_user.username, password=TEST_PASSWORD)
@@ -586,7 +665,8 @@ class EditTeamMembershitTestCase(TeamsTestsBaseClass):
         self.assertEqual(response.status_code, 404)
 
     def test_case_user_is_staff_and_team_exists_for_provided_team_id(self):
-        """Test that correct number of team members are displayed for their membership to be edited when current user
+        """
+        Test that correct number of team members are displayed for their membership to be edited when current user
         is a staff user and there is existing team for provided team_id
         """
         team_member_selector = 'li.team-member'

--- a/openedx/features/teams/urls.py
+++ b/openedx/features/teams/urls.py
@@ -3,7 +3,8 @@
 from django.conf.urls import url
 
 from lms.djangoapps.teams.api_urls import TEAM_ID_PATTERN, TOPIC_ID_PATTERN
-from .views import browse_teams, create_team, my_team, browse_topic_teams, update_team, view_team, edit_team_memberships
+
+from .views import browse_teams, browse_topic_teams, create_team, edit_team_memberships, my_team, update_team, view_team
 
 urlpatterns = [
     url(r"^browse_teams/$", browse_teams, name="teams_dashboard"),

--- a/openedx/features/teams/views.py
+++ b/openedx/features/teams/views.py
@@ -1,31 +1,26 @@
-from w3lib.url import add_or_replace_parameter
-
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.urlresolvers import reverse
 from django.http import Http404
-from django.shortcuts import render_to_response, redirect
+from django.shortcuts import redirect, render_to_response
 from django.utils.translation import ugettext as _
-from django_comment_client.utils import has_discussion_privileges
 from django_countries import countries
+from w3lib.url import add_or_replace_parameter
 
-from nodebb.constants import TEAM_PLAYER_ENTRY_INDEX
 from courseware.courses import has_access
+from django_comment_client.utils import has_discussion_privileges
 from lms.djangoapps.teams import is_feature_enabled
 from lms.djangoapps.teams.models import CourseTeam, CourseTeamMembership
-from lms.djangoapps.teams.serializers import (
-    BulkTeamCountTopicSerializer,
-)
+from lms.djangoapps.teams.serializers import BulkTeamCountTopicSerializer
 from lms.djangoapps.teams.views import get_alphabetical_topics
+from nodebb.constants import TEAM_PLAYER_ENTRY_INDEX
 from nodebb.models import TeamGroupChat
-from openedx.features.badging.models import Badge
 from openedx.features.badging.constants import TEAM_PLAYER
+from openedx.features.badging.models import Badge
 from student.models import CourseEnrollment
 
-
 from .decorators import can_view_teams
-from .helpers import serialize, make_embed_url, get_user_recommended_team, \
-    get_user_course_with_access, get_team_topic
+from .helpers import get_team_topic, get_user_course_with_access, get_user_recommended_team, make_embed_url, serialize
 from .serializers import CustomCourseTeamSerializer
 
 

--- a/openedx/features/teams/views.py
+++ b/openedx/features/teams/views.py
@@ -1,9 +1,9 @@
+""" All the view of teams application"""
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.urlresolvers import reverse
 from django.http import Http404
 from django.shortcuts import redirect, render_to_response
-from django.utils.translation import ugettext as _
 from django_countries import countries
 from w3lib.url import add_or_replace_parameter
 
@@ -26,6 +26,15 @@ from .serializers import CustomCourseTeamSerializer
 
 @login_required
 def browse_teams(request, course_id):
+    """ The view for listing recommended teams for learners based on their region. This is view also responsible
+    for listing all the available regions with all the teams
+    :param HttpRequest request: Http request object
+    :param string course_id: Id of a course
+    :return: Http response with template and context
+    :rtype: HttpResponse
+    :raises Http404: If feature is not enabled or user is not enrolled in the course or the course instructor user does
+    not have stuff level access
+    """
     user = request.user
     course = get_user_course_with_access(course_id, user)
 
@@ -72,12 +81,21 @@ def browse_teams(request, course_id):
 @can_view_teams
 @login_required
 def browse_topic_teams(request, course_id, topic_id):
+    """ The view for listing all existing teams in a specific region
+    :param HttpRequest request: Http request object
+    :param string course_id: Id of a course
+    :param string topic_id: The if of region i.e. AsiaPacific, EuropeWestAsia etc
+    :return: Http response with template and context
+    :rtype: HttpResponse
+    :raises Http404: If no topic found corresponding to topic_id
+    """
     user = request.user
     course = get_user_course_with_access(course_id, user)
 
-    topics = [t for t in course.teams_topics if t['id'] == topic_id]
+    topics = [topic for topic in course.teams_topics if topic['id'] == topic_id]
+    no_of_topics = len(topics)  # pylint < 2.4.0 throws linting error on using len() in if condition
 
-    if len(topics) == 0:
+    if no_of_topics == 0:
         raise Http404
 
     topic_teams = CourseTeam.objects.filter(course_id=course.id, topic_id=topics[0]['id']).all()
@@ -105,6 +123,16 @@ def browse_topic_teams(request, course_id, topic_id):
 @can_view_teams
 @login_required
 def create_team(request, course_id, topic_id=None):
+    """ The view for creating new team. If topic id is provided in the link then corresponding region will be auto
+    selected, otherwise region will be populated and user can select it from page. One user can create only one team
+    at a time; user cannot create team if it is member of any other team.
+    :param HttpRequest request: Http request object
+    :param string course_id: Id of a course
+    :param string topic_id: The if of region i.e. AsiaPacific, EuropeWestAsia etc
+    :return: Http response with template and context
+    :rtype: HttpResponse
+    :raises Http404: If topic_id is provided in url but no topic found corresponding to topic_id
+    """
     user = request.user
     course = get_user_course_with_access(course_id, user)
     topic = get_team_topic(course, topic_id)
@@ -118,7 +146,7 @@ def create_team(request, course_id, topic_id=None):
         'course': course,
         'user_has_privilege': not is_member_of_any_team,
         'countries': list(countries),
-        'languages': [[lang[0], _(lang[1])] for lang in settings.ALL_LANGUAGES],
+        'languages': [[lang[0], lang[1]] for lang in settings.ALL_LANGUAGES],
         'topic': topic,
         'topics': course.teams_topics,
         'template_view': 'create'
@@ -130,6 +158,12 @@ def create_team(request, course_id, topic_id=None):
 @can_view_teams
 @login_required
 def my_team(request, course_id):
+    """ The view for listing all teams current user is member of
+    :param HttpRequest request: Http request object
+    :param string course_id: Id of a course
+    :return: Http response with template and context
+    :rtype: HttpResponse
+    """
     user = request.user
     course = get_user_course_with_access(course_id, user)
 
@@ -152,6 +186,15 @@ def my_team(request, course_id):
 @can_view_teams
 @login_required
 def view_team(request, course_id, team_id):
+    """ The view for presenting team page to learners.
+    :param HttpRequest request: Http request object
+    :param string course_id: Id of a course
+    :param string team_id: Id of team
+    :return: Http response with template and context
+    :rtype: HttpResponse
+    :raises Http404: If CourseTeam is not found corresponding to team_id or that CourseTeam does not have associated
+    TeamGroupChat
+    """
     user = request.user
     course = get_user_course_with_access(course_id, user)
 
@@ -199,6 +242,15 @@ def view_team(request, course_id, team_id):
 @can_view_teams
 @login_required
 def update_team(request, course_id, team_id):
+    """ Team admin can update team's name, description, language and country
+    :param HttpRequest request: Http request object
+    :param string course_id: Id of a course
+    :param string team_id: Id of team
+    :return: Http response with template and context
+    :rtype: HttpResponse
+    :raises Http404: If the user who is making request, does not have admin access or necessary privileges
+
+    """
     user = request.user
     course = get_user_course_with_access(course_id, user)
 
@@ -216,7 +268,7 @@ def update_team(request, course_id, team_id):
         'course': course,
         'team': team,
         'countries': list(countries),
-        'languages': [[lang[0], _(lang[1])] for lang in settings.ALL_LANGUAGES],
+        'languages': [[lang[0], lang[1]] for lang in settings.ALL_LANGUAGES],
         'user_has_privilege': team_administrator,
         'template_view': 'update'
     }
@@ -227,6 +279,14 @@ def update_team(request, course_id, team_id):
 @can_view_teams
 @login_required
 def edit_team_memberships(request, course_id, team_id):
+    """ Team admin can edit team membership and remove non-participating members.
+    :param HttpRequest request: Http request object
+    :param string course_id: Id of a course
+    :param string team_id: Id of team
+    :return: Http response with template and context
+    :rtype: HttpResponse
+    :raises Http404: If the user who is making request, does not have admin access or necessary privileges
+    """
     user = request.user
     course = get_user_course_with_access(course_id, user)
 

--- a/openedx/features/teams/views.py
+++ b/openedx/features/teams/views.py
@@ -1,4 +1,6 @@
-""" All the view of teams application"""
+"""
+All the view of teams application
+"""
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.urlresolvers import reverse
@@ -26,8 +28,10 @@ from .serializers import CustomCourseTeamSerializer
 
 @login_required
 def browse_teams(request, course_id):
-    """ The view for listing recommended teams for learners based on their region. This is view also responsible
+    """
+    The view for listing recommended teams for learners based on their region. This is view also responsible
     for listing all the available regions with all the teams
+
     :param HttpRequest request: Http request object
     :param string course_id: Id of a course
     :return: Http response with template and context
@@ -81,7 +85,9 @@ def browse_teams(request, course_id):
 @can_view_teams
 @login_required
 def browse_topic_teams(request, course_id, topic_id):
-    """ The view for listing all existing teams in a specific region
+    """
+    The view for listing all existing teams in a specific region
+
     :param HttpRequest request: Http request object
     :param string course_id: Id of a course
     :param string topic_id: The if of region i.e. AsiaPacific, EuropeWestAsia etc
@@ -123,9 +129,11 @@ def browse_topic_teams(request, course_id, topic_id):
 @can_view_teams
 @login_required
 def create_team(request, course_id, topic_id=None):
-    """ The view for creating new team. If topic id is provided in the link then corresponding region will be auto
+    """
+    The view for creating new team. If topic id is provided in the link then corresponding region will be auto
     selected, otherwise region will be populated and user can select it from page. One user can create only one team
     at a time; user cannot create team if it is member of any other team.
+
     :param HttpRequest request: Http request object
     :param string course_id: Id of a course
     :param string topic_id: The if of region i.e. AsiaPacific, EuropeWestAsia etc
@@ -158,7 +166,9 @@ def create_team(request, course_id, topic_id=None):
 @can_view_teams
 @login_required
 def my_team(request, course_id):
-    """ The view for listing all teams current user is member of
+    """
+    The view for listing all teams current user is member of
+
     :param HttpRequest request: Http request object
     :param string course_id: Id of a course
     :return: Http response with template and context
@@ -186,7 +196,9 @@ def my_team(request, course_id):
 @can_view_teams
 @login_required
 def view_team(request, course_id, team_id):
-    """ The view for presenting team page to learners.
+    """
+    The view for presenting team page to learners.
+
     :param HttpRequest request: Http request object
     :param string course_id: Id of a course
     :param string team_id: Id of team
@@ -242,7 +254,9 @@ def view_team(request, course_id, team_id):
 @can_view_teams
 @login_required
 def update_team(request, course_id, team_id):
-    """ Team admin can update team's name, description, language and country
+    """
+    Team admin can update team's name, description, language and country
+
     :param HttpRequest request: Http request object
     :param string course_id: Id of a course
     :param string team_id: Id of team
@@ -279,7 +293,9 @@ def update_team(request, course_id, team_id):
 @can_view_teams
 @login_required
 def edit_team_memberships(request, course_id, team_id):
-    """ Team admin can edit team membership and remove non-participating members.
+    """
+    Team admin can edit team membership and remove non-participating members.
+
     :param HttpRequest request: Http request object
     :param string course_id: Id of a course
     :param string team_id: Id of team


### PR DESCRIPTION
### Description

[LP-2292](https://philanthropyu.atlassian.net/browse/LP-2292) Fix all linting errors for openedx/features/teams

### Notes

- [x] Final pylint score for teams app is 10/10. See all reported pylint violation below
- [x] pylintrc file updated using edx command `edx_lint write pylintrc` after updating pylintrc_tweaks
- [x] Ran iSort on whole app
- [x] All tests are passing
- [x] Posted all violations as a comment on the story

```
************* Module edx-platform.openedx.features.teams.mixins
C:  1, 0: Missing module docstring (missing-docstring)
C:  5, 0: First line empty in class docstring (docstring-first-line-empty)
************* Module edx-platform.openedx.features.teams.serializers
C: 12, 0: First line empty in class docstring (docstring-first-line-empty)
C: 17, 4: First line empty in method docstring (docstring-first-line-empty)
C: 38, 0: First line empty in class docstring (docstring-first-line-empty)
C: 45, 4: First line empty in method docstring (docstring-first-line-empty)
W: 45, 4: Parameters differ from overridden 'to_representation' method (arguments-differ)
C: 51, 4: First line empty in method docstring (docstring-first-line-empty)
C: 77, 0: Missing class docstring (missing-docstring)
W: 89,32: Unused argument 'membership' (unused-argument)
C: 99, 0: Missing class docstring (missing-docstring)
W:120,31: Unused argument 'course_team' (unused-argument)
************* Module edx-platform.openedx.features.teams.helpers
C:  1, 0: Missing module docstring (missing-docstring)
C: 20, 0: First line empty in function docstring (docstring-first-line-empty)
W: 20, 0: "many, queryset, request, serializer_cls" missing in parameter documentation (missing-param-doc)
W: 20, 0: "queryset, request, serializer_cls" missing in parameter type documentation (missing-type-doc)
W: 20, 0: Missing return documentation (missing-return-doc)
W: 20, 0: Missing return type documentation (missing-return-type-doc)
C: 59, 0: Missing function docstring (missing-docstring)
C: 67, 0: First line empty in function docstring (docstring-first-line-empty)
W: 67, 0: "course_id, user" missing in parameter type documentation (missing-type-doc)
W: 67, 0: Missing return type documentation (missing-return-type-doc)
C: 80, 0: Missing function docstring (missing-docstring)
W: 84,13: map/filter on lambda could be replaced by comprehension (deprecated-lambda)
************* Module edx-platform.openedx.features.teams.views
C:  1, 0: Missing module docstring (missing-docstring)
C: 33, 0: Missing function docstring (missing-docstring)
C: 79, 0: Missing function docstring (missing-docstring)
C: 85, 7: Do not use `len(SEQUENCE)` as condition value (len-as-condition)
C:112, 0: Missing function docstring (missing-docstring)
E:126,32: i18n function _() must be called with a literal string (translation-of-non-string)
C:137, 0: Missing function docstring (missing-docstring)
C:159, 0: Missing function docstring (missing-docstring)
C:206, 0: Missing function docstring (missing-docstring)
E:224,32: i18n function _() must be called with a literal string (translation-of-non-string)
C:234, 0: Missing function docstring (missing-docstring)
C: 20, 0: Imports from package nodebb are not grouped (ungrouped-imports)
************* Module edx-platform.openedx.features.teams.decorators
C:  1, 0: Missing module docstring (missing-docstring)
C:  7, 0: Missing function docstring (missing-docstring)
C:  8, 4: Missing function docstring (missing-docstring)
************* Module edx-platform.openedx.features.teams.tests.test_serializers
C:  1, 0: Missing module docstring (missing-docstring)
************* Module edx-platform.openedx.features.teams.tests.factories
C:  1, 0: First line empty in module docstring (docstring-first-line-empty)
W: 22,38: Unused argument 'expected' (unused-argument)
************* Module edx-platform.openedx.features.teams.tests.test_views
C:  1, 0: Missing module docstring (missing-docstring)
W: 49,12: Unused variable 'i' (unused-variable)
W: 81, 4: Missing return documentation (missing-return-doc)
W: 81, 4: Missing return type documentation (missing-return-type-doc)
W: 97, 4: Missing return documentation (missing-return-doc)
W: 97, 4: Missing return type documentation (missing-return-type-doc)
W:109, 4: Missing return type documentation (missing-return-type-doc)
W:123, 4: Missing return type documentation (missing-return-type-doc)
W:214, 8: Unused variable 'enrolled_user' (unused-variable)
C: 20, 0: Imports from package openedx are not grouped (ungrouped-imports)
************* Module edx-platform.openedx.features.teams.tests.test_helpers
C: 99, 0: Line too long (124/120) (line-too-long)
C:  1, 0: Missing module docstring (missing-docstring)
W: 67, 4: Missing return type documentation (missing-return-type-doc)

-----------------------------------
Your code has been rated at 9.22/10
```


