### PR TITLE
LP-1296 Notification icon count bug at LMS

### DIFF
--- a/common/static/common/templates/notifications/notifications_count.underscore
+++ b/common/static/common/templates/notifications/notifications_count.underscore
@@ -1,6 +1,6 @@
 <%
 if (count > 0) {
-    count = (count>99)?"99+":count;
+    count = count > 99 ? '99+' : count;
 %>
     <span id="notification-count">
         <%=count %>

--- a/common/static/common/templates/notifications/notifications_count.underscore
+++ b/common/static/common/templates/notifications/notifications_count.underscore
@@ -1,5 +1,7 @@
-
-<% if (count > 0) { %>
+<%
+if (count > 0) {
+    count = (count>99)?"99+":count;
+%>
     <span id="notification-count">
         <%=count %>
     </span>


### PR DESCRIPTION
### Description

[LP-1296](https://philanthropyu.atlassian.net/browse/LP-1296)

When notifications counts exceeds 99 then it should be displayed 99+ at LMS side too.