### PR TITLE
LP-2279 Fix all linting issues of philu_api

### DIFF
--- a/lms/djangoapps/philu_api/helpers.py
+++ b/lms/djangoapps/philu_api/helpers.py
@@ -1,3 +1,6 @@
+"""
+Helpers for philu_api application
+"""
 from urllib import urlencode
 
 import jwt
@@ -8,19 +11,19 @@ from custom_settings.models import CustomSettings
 from lms.envs.common import SOCIAL_SHARING_URLS, TWITTER_MESSAGE_FORMAT
 
 
-def get_encoded_token(username, email, id):
-    return jwt.encode({'id': id, 'username': username, 'email': email}, 'secret', algorithm='HS256')
+def get_encoded_token(username, email, _id):
+    return jwt.encode({'id': _id, 'username': username, 'email': email}, 'secret', algorithm='HS256')
 
 
 def get_course_custom_settings(course_key):
     """ Return course custom settings object """
-    if isinstance(course_key, str) or isinstance(course_key, unicode):
+    if isinstance(course_key, (str, unicode)):
         course_key = CourseKey.from_string(course_key)
 
     return CustomSettings.objects.filter(id=course_key).first()
 
 
-def get_social_sharing_urls(course_url, meta_tags, tweet_text=None):
+def get_social_sharing_urls(course_url, meta_tags):
     utm_params = meta_tags['utm_params'].copy()
     course_share_url = '{}?{}'.format(course_url, urlencode(utm_params))
 
@@ -60,6 +63,15 @@ def get_social_sharing_urls(course_url, meta_tags, tweet_text=None):
 
 
 def _compile_social_sharing_url(share_url, course_url, url_param, utm_source, text=None):
+    """
+    Create social sharing url by combining url and parameters
+    @param share_url: social platform url
+    @param course_url: course url
+    @param url_param: url parameters
+    @param utm_source: social platform source i.e. Facebook, LinkedIn, Twitter
+    @param text: url text parameter
+    @return: social sharing url
+    """
     course_url_with_utm = add_or_replace_parameter(course_url, 'utm_source', utm_source)
 
     # Introduced for the email case where the addThis widget is being used

--- a/lms/djangoapps/philu_api/helpers.py
+++ b/lms/djangoapps/philu_api/helpers.py
@@ -1,10 +1,11 @@
-import jwt
-from custom_settings.models import CustomSettings
-from opaque_keys.edx.keys import CourseKey
 from urllib import urlencode
+
+import jwt
+from opaque_keys.edx.keys import CourseKey
 from w3lib.url import add_or_replace_parameter
 
-from lms.envs.common import (SOCIAL_SHARING_URLS, TWITTER_MESSAGE_FORMAT)
+from custom_settings.models import CustomSettings
+from lms.envs.common import SOCIAL_SHARING_URLS, TWITTER_MESSAGE_FORMAT
 
 
 def get_encoded_token(username, email, id):

--- a/lms/djangoapps/philu_api/tests/test_views.py
+++ b/lms/djangoapps/philu_api/tests/test_views.py
@@ -1,9 +1,9 @@
 import json
-from mock import patch
 
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.test import RequestFactory, TestCase
+from mock import patch
 
 from lms.djangoapps.philu_api.views import assign_user_badge
 

--- a/lms/djangoapps/philu_api/urls.py
+++ b/lms/djangoapps/philu_api/urls.py
@@ -1,12 +1,22 @@
 """
  API urls to communicate with nodeBB
 """
+
 from django.conf.urls import url
 
-from lms.djangoapps.philu_api.views import PlatformSyncService, \
-    get_user_chat, mark_user_chat_read, get_user_data, MailChimpDataSyncAPI, \
-    ThirdPartyResultDataSyncAPI, download_pdf_file, send_alquity_fake_confirmation_email, \
-    UpdatePromptClickRecord, assign_user_badge, resend_activation_email
+from lms.djangoapps.philu_api.views import (
+    MailChimpDataSyncAPI,
+    PlatformSyncService,
+    ThirdPartyResultDataSyncAPI,
+    UpdatePromptClickRecord,
+    assign_user_badge,
+    download_pdf_file,
+    get_user_chat,
+    get_user_data,
+    mark_user_chat_read,
+    resend_activation_email,
+    send_alquity_fake_confirmation_email
+)
 
 urlpatterns = [
     url(r'platform/sync/service/', PlatformSyncService.as_view(), name='get_shared_data'),

--- a/lms/djangoapps/philu_api/views.py
+++ b/lms/djangoapps/philu_api/views.py
@@ -3,36 +3,32 @@ restAPI Views
 """
 import json
 import logging
-import requests
 import urllib
-
-from rest_framework import status
-from rest_framework.views import APIView
-from util.json_request import expect_json
 from wsgiref.util import FileWrapper
 
-from django.core.urlresolvers import reverse
-from django.conf import settings
-from django.http import JsonResponse, HttpResponse, Http404
-from django.views.decorators.http import require_POST
-from django.views.decorators.csrf import csrf_exempt
-
+import requests
 from celery.result import AsyncResult
-from common.lib.mandrill_client.client import MandrillClient
-from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
-from openedx.features.badging.models import Badge, UserBadge
-from openedx.features.partners.helpers import get_partner_from_user, user_has_performance_access
+from django.conf import settings
+from django.core.urlresolvers import reverse
+from django.http import Http404, HttpResponse, JsonResponse
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_POST
+from rest_framework import status
+from rest_framework.views import APIView
 
+from common.lib.mandrill_client.client import MandrillClient
 from lms.djangoapps.oef.decorators import eligible_for_oef
 from lms.djangoapps.onboarding.helpers import get_org_metric_update_prompt
 from lms.djangoapps.onboarding.models import MetricUpdatePromptRecord
 from lms.djangoapps.philu_api.helpers import get_encoded_token
 from lms.djangoapps.third_party_surveys.tasks import get_third_party_surveys_task
-
 from mailchimp_pipeline.tasks import update_enrollments_completions_at_mailchimp
-from student.models import User
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+from openedx.features.badging.models import Badge, UserBadge
+from openedx.features.partners.helpers import get_partner_from_user, user_has_performance_access
 from philu_overrides.helpers import reactivation_email_for_user_custom
-
+from student.models import User
+from util.json_request import expect_json
 
 log = logging.getLogger("edx.philu_api")
 

--- a/lms/djangoapps/philu_api/views.py
+++ b/lms/djangoapps/philu_api/views.py
@@ -214,9 +214,11 @@ def get_user_chat(request):
     chat_endpoint = settings.NODEBB_ENDPOINT + '/api/v2/users/chats'
     username = request.user.username
     headers = {'Authorization': 'Bearer ' + settings.NODEBB_MASTER_TOKEN}
-    response = requests.post(chat_endpoint,
-                             data={'_uid': 1, 'username': username},
-                             headers=headers)
+    response = requests.post(
+        chat_endpoint,
+        data={'_uid': 1, 'username': username},
+        headers=headers
+    )
     return JsonResponse(response.json())
 
 
@@ -225,9 +227,11 @@ def mark_user_chat_read(request):
     chat_endpoint = settings.NODEBB_ENDPOINT + '/api/v2/users/chats'
     username = request.user.username
     headers = {'Authorization': 'Bearer ' + settings.NODEBB_MASTER_TOKEN}
-    response = requests.patch(chat_endpoint,
-                              data={'_uid': 1, 'username': username},
-                              headers=headers)
+    response = requests.patch(
+        chat_endpoint,
+        data={'_uid': 1, 'username': username},
+        headers=headers
+    )
     return JsonResponse(response.json())
 
 
@@ -236,9 +240,11 @@ def get_user_data(request):
     data_endpoint = settings.NODEBB_ENDPOINT + '/api/v2/users/data'
     username = request.POST.get("username")
     headers = {'Authorization': 'Bearer ' + settings.NODEBB_MASTER_TOKEN}
-    response = requests.post(data_endpoint,
-                             data={'_uid': 1, 'username': username},
-                             headers=headers)
+    response = requests.post(
+        data_endpoint,
+        data={'_uid': 1, 'username': username},
+        headers=headers
+    )
     return JsonResponse(response.json())
 
 
@@ -294,7 +300,7 @@ def resend_activation_email(request):
         else:
             # the user's account has already been activated
             activation_response = JsonResponse(data={}, status=status.HTTP_409_CONFLICT)
-    except Exception as ex: # pylint: disable=broad-except
+    except Exception as ex:  # pylint: disable=broad-except
         logging.exception(ex)
         activation_response = JsonResponse(data={}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 

--- a/openedx/features/student_certificates/helpers.py
+++ b/openedx/features/student_certificates/helpers.py
@@ -154,18 +154,11 @@ def get_philu_certificate_social_context(course, certificate):
     custom_settings = get_course_custom_settings(course.id)
     meta_tags = custom_settings.get_course_meta_tags()
 
-    tweet_text = TWITTER_TWEET_TEXT_FMT.format(
-        course_name=course.display_name,
-        base_url=settings.LMS_ROOT_URL,
-        course_url='courses',
-        course_id=course.id,
-        about_url='about')
-
     meta_tags['title'] = TWITTER_META_TITLE_FMT.format(course_name=course.display_name)
 
     social_sharing_urls = get_social_sharing_urls(SOCIAL_MEDIA_SHARE_URL_FMT.format(
         base_url=settings.LMS_ROOT_URL,
-        certificate_uuid=certificate.verify_uuid), meta_tags, tweet_text)
+        certificate_uuid=certificate.verify_uuid), meta_tags)
 
     return social_sharing_urls
 


### PR DESCRIPTION
### Description

[LP-2279](https://philanthropyu.atlassian.net/browse/LP-2279)

### Notes
I have suppressed borad-except warning from pylint on couple of places. The reason being they were placed there to catch all exceptions and logged the errors. As per pep8

** A good rule of thumb is to limit use of bare 'except' clauses to two cases:

1. If the exception handler will be printing out or logging the traceback; at least the user will be aware that an error has occurred.
2. If the code needs to do some cleanup work, but then lets the exception propagate upwards with raise. try...finally can be a better way to handle this case.


### Final report:
```
--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)
```