### PR TITLE
LP-2254 philu_overrides.context_processor unit tests

### DIFF
--- a/lms/djangoapps/philu_overrides/constants.py
+++ b/lms/djangoapps/philu_overrides/constants.py
@@ -1,3 +1,5 @@
+from django.conf import settings
+
 ACTIVATION_ERROR_MSG_FORMAT = '<span id="resend-activation-span"> Your account has not been activated. Please check your email to activate your account. <a id="resend-activation-link" class="click-here-link" href="{api_endpoint}" data-user-id={user_id}> Resend Activation Email </a></span>'
 
 ORG_DETAILS_UPDATE_ALERT = 'It has been more than a year since you updated these numbers. Are they still correct?'
@@ -5,3 +7,9 @@ ORG_OEF_UPDATE_ALERT = 'It has been more than a year since you submitted your OE
 ACTIVATION_ALERT_TYPE = 'activation'
 ENROLL_SHARE_TITLE_FORMAT = "Let's take this {} course together"
 ENROLL_SHARE_DESC_FORMAT = "I just enrolled in Philanthropy University's {} course. Let's take it together!"
+
+ORG_OEF_UPDATE_ALERT_MSG_DICT = {'type': ACTIVATION_ALERT_TYPE, 'alert': ORG_OEF_UPDATE_ALERT}
+ORG_DETAILS_UPDATE_ALERT_MSG_DICT = {'type': ACTIVATION_ALERT_TYPE, 'alert': ORG_DETAILS_UPDATE_ALERT}
+
+NODEBB_END_POINT_DICT = {'nodebb_endpoint': settings.NODEBB_ENDPOINT}
+CDN_LINK_DICT = {'cdn_link': settings.CDN_LINK}

--- a/lms/djangoapps/philu_overrides/context_processor.py
+++ b/lms/djangoapps/philu_overrides/context_processor.py
@@ -1,6 +1,3 @@
-from django.conf import settings
-from django.urls import reverse
-
 from lms.djangoapps.onboarding.helpers import (
     get_org_metric_update_prompt,
     get_org_oef_update_prompt,
@@ -9,11 +6,12 @@ from lms.djangoapps.onboarding.helpers import (
     is_org_oef_prompt_available
 )
 from lms.djangoapps.philu_overrides.constants import (
-    ACTIVATION_ALERT_TYPE,
-    ACTIVATION_ERROR_MSG_FORMAT,
-    ORG_DETAILS_UPDATE_ALERT,
-    ORG_OEF_UPDATE_ALERT
+    CDN_LINK_DICT,
+    NODEBB_END_POINT_DICT,
+    ORG_DETAILS_UPDATE_ALERT_MSG_DICT,
+    ORG_OEF_UPDATE_ALERT_MSG_DICT
 )
+from lms.djangoapps.philu_overrides.helpers import get_activation_alert_error_msg_dict
 
 
 def get_global_alert_messages(request):
@@ -33,29 +31,18 @@ def get_global_alert_messages(request):
 
     if not request.is_ajax():
         if request.user.is_authenticated() and not request.user.is_active and '/activate/' not in request.path:
-            global_alert_messages.append({
-                'type': ACTIVATION_ALERT_TYPE,
-                'alert': ACTIVATION_ERROR_MSG_FORMAT.format(
-                    api_endpoint=reverse('resend_activation_email'),
-                    user_id=request.user.id
-                )
-            })
+            global_alert_message = get_activation_alert_error_msg_dict(request.user.id)
+            global_alert_messages.append(global_alert_message)
 
     if '/oef/dashboard' in request.path:
         oef_update_prompt = get_org_oef_update_prompt(request.user)
         show_oef_prompt = oef_update_prompt and is_org_oef_prompt_available(oef_update_prompt)
         if show_oef_prompt:
-            global_alert_messages.append({
-                'type': ACTIVATION_ALERT_TYPE,
-                'alert': ORG_OEF_UPDATE_ALERT
-            })
+            global_alert_messages.append(ORG_OEF_UPDATE_ALERT_MSG_DICT)
             oef_prompt = True
 
     elif '/organization/details/' in request.path and show_org_detail_prompt:
-        global_alert_messages.append({
-            'type': ACTIVATION_ALERT_TYPE,
-            'alert': ORG_DETAILS_UPDATE_ALERT
-        })
+        global_alert_messages.append(ORG_DETAILS_UPDATE_ALERT_MSG_DICT)
 
     elif metric_update_prompt and show_org_detail_prompt\
             and is_org_detail_platform_overlay_available(metric_update_prompt):
@@ -72,12 +59,11 @@ def add_nodebb_endpoint(request):
     """
     Add our NODEBB_ENDPOINT to the template context so that it can be referenced by any client side code.
     """
-    return {'nodebb_endpoint': settings.NODEBB_ENDPOINT}
+    return NODEBB_END_POINT_DICT
 
 
 def get_cdn_link(request):
     """
-    return CDN url link to templates
-    :return:
+    Return CDN url link to templates
     """
-    return {'cdn_link': settings.CDN_LINK}
+    return CDN_LINK_DICT

--- a/lms/djangoapps/philu_overrides/context_processor.py
+++ b/lms/djangoapps/philu_overrides/context_processor.py
@@ -1,17 +1,24 @@
 from django.conf import settings
 from django.urls import reverse
 
-from lms.djangoapps.onboarding.helpers import get_org_metric_update_prompt, \
-    is_org_detail_prompt_available, is_org_detail_platform_overlay_available, \
-    get_org_oef_update_prompt, is_org_oef_prompt_available
-from lms.djangoapps.philu_overrides.constants import ACTIVATION_ALERT_TYPE, ACTIVATION_ERROR_MSG_FORMAT, \
-    ORG_DETAILS_UPDATE_ALERT, ORG_OEF_UPDATE_ALERT
+from lms.djangoapps.onboarding.helpers import (
+    get_org_metric_update_prompt,
+    get_org_oef_update_prompt,
+    is_org_detail_platform_overlay_available,
+    is_org_detail_prompt_available,
+    is_org_oef_prompt_available
+)
+from lms.djangoapps.philu_overrides.constants import (
+    ACTIVATION_ALERT_TYPE,
+    ACTIVATION_ERROR_MSG_FORMAT,
+    ORG_DETAILS_UPDATE_ALERT,
+    ORG_OEF_UPDATE_ALERT
+)
 
 
 def get_global_alert_messages(request):
-
     """
-    function to get application wide messages
+    Get application wide messages
     :param request:
     :return: returns list of global messages"
     """
@@ -24,14 +31,14 @@ def get_global_alert_messages(request):
     metric_update_prompt = get_org_metric_update_prompt(request.user)
     show_org_detail_prompt = metric_update_prompt and is_org_detail_prompt_available(metric_update_prompt)
 
-    oef_update_prompt = get_org_oef_update_prompt(request.user)
-    show_oef_prompt = oef_update_prompt and is_org_oef_prompt_available(oef_update_prompt)
-
     if not request.is_ajax():
         if request.user.is_authenticated() and not request.user.is_active and '/activate/' not in request.path:
             global_alert_messages.append({
-                "type": ACTIVATION_ALERT_TYPE,
-                "alert": ACTIVATION_ERROR_MSG_FORMAT.format(api_endpoint=reverse('resend_activation_email'), user_id=request.user.id)
+                'type': ACTIVATION_ALERT_TYPE,
+                'alert': ACTIVATION_ERROR_MSG_FORMAT.format(
+                    api_endpoint=reverse('resend_activation_email'),
+                    user_id=request.user.id
+                )
             })
 
     if '/oef/dashboard' in request.path:
@@ -39,29 +46,33 @@ def get_global_alert_messages(request):
         show_oef_prompt = oef_update_prompt and is_org_oef_prompt_available(oef_update_prompt)
         if show_oef_prompt:
             global_alert_messages.append({
-                "type": ACTIVATION_ALERT_TYPE,
-                "alert": ORG_OEF_UPDATE_ALERT
+                'type': ACTIVATION_ALERT_TYPE,
+                'alert': ORG_OEF_UPDATE_ALERT
             })
             oef_prompt = True
 
     elif '/organization/details/' in request.path and show_org_detail_prompt:
         global_alert_messages.append({
-            "type": ACTIVATION_ALERT_TYPE,
-            "alert": ORG_DETAILS_UPDATE_ALERT
+            'type': ACTIVATION_ALERT_TYPE,
+            'alert': ORG_DETAILS_UPDATE_ALERT
         })
 
     elif metric_update_prompt and show_org_detail_prompt\
             and is_org_detail_platform_overlay_available(metric_update_prompt):
         overlay_message = True
 
-    return {"global_alert_messages": global_alert_messages, "overlay_message": overlay_message, "oef_prompt": oef_prompt}
+    return {
+        'global_alert_messages': global_alert_messages,
+        'overlay_message': overlay_message,
+        'oef_prompt': oef_prompt
+    }
 
 
 def add_nodebb_endpoint(request):
     """
     Add our NODEBB_ENDPOINT to the template context so that it can be referenced by any client side code.
     """
-    return { "nodebb_endpoint": settings.NODEBB_ENDPOINT }
+    return {'nodebb_endpoint': settings.NODEBB_ENDPOINT}
 
 
 def get_cdn_link(request):
@@ -69,4 +80,4 @@ def get_cdn_link(request):
     return CDN url link to templates
     :return:
     """
-    return {"cdn_link": settings.CDN_LINK}
+    return {'cdn_link': settings.CDN_LINK}

--- a/lms/djangoapps/philu_overrides/helpers.py
+++ b/lms/djangoapps/philu_overrides/helpers.py
@@ -1,17 +1,19 @@
 import json
-
-import pytz
 from datetime import datetime
 
+import pytz
+from django.urls import reverse
+
+from common.lib.mandrill_client.client import MandrillClient
+from lms.djangoapps.courseware.courses import get_course_by_id
 from lms.djangoapps.onboarding.constants import ORG_PARTNERSHIP_END_DATE_PLACEHOLDER
 from lms.djangoapps.onboarding.models import GranteeOptIn
-
+from lms.djangoapps.philu_overrides.constants import ACTIVATION_ALERT_TYPE, ACTIVATION_ERROR_MSG_FORMAT
 from openedx.core.djangoapps.models.course_details import CourseDetails
-from lms.djangoapps.courseware.courses import get_course_by_id
+from openedx.core.lib.request_utils import safe_get_host
 from student.models import Registration
 from util.json_request import JsonResponse
-from openedx.core.lib.request_utils import safe_get_host
-from common.lib.mandrill_client.client import MandrillClient
+
 utc = pytz.UTC
 
 
@@ -270,3 +272,13 @@ def save_user_partner_network_consent(user, _data):
                     organization_partner=organization_partner,
                     user=user
                 )
+
+
+def get_activation_alert_error_msg_dict(user_id):
+    return {
+        'type': ACTIVATION_ALERT_TYPE,
+        'alert': ACTIVATION_ERROR_MSG_FORMAT.format(
+            api_endpoint=reverse('resend_activation_email'),
+            user_id=user_id
+        )
+    }

--- a/lms/djangoapps/philu_overrides/tests/test_context_processor.py
+++ b/lms/djangoapps/philu_overrides/tests/test_context_processor.py
@@ -78,7 +78,7 @@ def test_get_activation_error_alert_message_ajax_failure(request_object):  # pyl
 
     request = request_object
     request.user.is_active = False
-    request.META["HTTP_X_REQUESTED_WITH"] = "XMLHttpRequest"  # so request.is_ajax() == True
+    request.META['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest'  # so request.is_ajax() == True
 
     expected_global_alert_message = []
     actual_global_alert_message = get_global_alert_messages(request).get('global_alert_messages')
@@ -141,7 +141,7 @@ def test_get_activation_error_alert_message_activation_url_failure(
 
     request = request_object
     request.user.is_active = False
-    request.path = request.path + '/activate/'  # append to url
+    request.path = request.path + '/activate/'
 
     expected_global_alert_message = []
     actual_global_alert_message = get_global_alert_messages(request).get('global_alert_messages')
@@ -169,7 +169,7 @@ def test_get_org_oef_update_alert_message_success(
     """
 
     request = request_object
-    request.path = request.path + '/oef/dashboard'  # append to url
+    request.path = request.path + '/oef/dashboard'
 
     mock_get_org_oef_update_prompt.return_value = True
     mock_is_org_oef_prompt_available.return_value = True
@@ -206,7 +206,7 @@ def test_get_org_oef_update_alert_message_oef_prompt_failure(
     """
 
     request = request_object
-    request.path = request.path + '/oef/dashboard'  # append to url
+    request.path = request.path + '/oef/dashboard'
 
     mock_get_org_oef_update_prompt.return_value = False
     mock_is_org_oef_prompt_available.return_value = True
@@ -238,7 +238,7 @@ def test_get_org_oef_update_alert_message_oef_available_failure(
     """
 
     request = request_object
-    request.path = request.path + '/oef/dashboard'  # append to url
+    request.path = request.path + '/oef/dashboard'
 
     mock_get_org_oef_update_prompt.return_value = True
     mock_is_org_oef_prompt_available.return_value = False
@@ -304,7 +304,7 @@ def test_get_org_details_update_alert_message_success(
     """
 
     request = request_object
-    request.path = request.path + '/organization/details/'  # append to url
+    request.path = request.path + '/organization/details/'
 
     mock_get_org_metric_update_prompt.return_value = True
     mock_is_org_detail_prompt_available.return_value = True
@@ -337,7 +337,7 @@ def test_get_org_details_update_alert_message_metric_prompt_failure(
     """
 
     request = request_object
-    request.path = request.path + '/organization/details/'  # append to url
+    request.path = request.path + '/organization/details/'
 
     mock_get_org_metric_update_prompt.return_value = False
     mock_is_org_detail_prompt_available.return_value = True
@@ -364,7 +364,7 @@ def test_get_org_details_update_alert_message_detail_prompt_failure(
     """
 
     request = request_object
-    request.path = request.path + '/organization/details/'  # append to url
+    request.path = request.path + '/organization/details/'
 
     mock_get_org_metric_update_prompt.return_value = True
     mock_is_org_detail_prompt_available.return_value = False
@@ -534,7 +534,7 @@ def test_overlay_message_oef_url_failure(
     """
 
     request = request_object
-    request.path = request.path + '/oef/dashboard'  # append to url
+    request.path = request.path + '/oef/dashboard'
 
     mock_get_org_metric_update_prompt.return_value = True
     mock_is_org_detail_prompt_available.return_value = True
@@ -562,7 +562,7 @@ def test_overlay_message_org_url_failure(
     """
 
     request = request_object
-    request.path = request.path + '/organization/details/'  # append to url
+    request.path = request.path + '/organization/details/'
 
     mock_get_org_metric_update_prompt.return_value = True
     mock_is_org_detail_prompt_available.return_value = True

--- a/lms/djangoapps/philu_overrides/tests/test_context_processor.py
+++ b/lms/djangoapps/philu_overrides/tests/test_context_processor.py
@@ -1,0 +1,590 @@
+"""
+Tests for context processors in philu_overrides
+"""
+
+import mock
+import pytest
+from django.conf import settings
+from django.test import RequestFactory
+from django.urls import reverse
+
+from lms.djangoapps.philu_overrides.constants import (
+    ACTIVATION_ALERT_TYPE,
+    ACTIVATION_ERROR_MSG_FORMAT,
+    ORG_DETAILS_UPDATE_ALERT,
+    ORG_OEF_UPDATE_ALERT
+)
+from lms.djangoapps.philu_overrides.context_processor import (
+    add_nodebb_endpoint,
+    get_cdn_link,
+    get_global_alert_messages
+)
+from student.tests.factories import AnonymousUserFactory, UserFactory
+
+
+@pytest.fixture()
+def request_object(db):  # pylint: disable=unused-argument
+    request = RequestFactory().get('/dummy_url')
+    request.user = UserFactory.create()
+    return request
+
+# Tests for get_global_alert_messages context processor
+
+# ACTIVATION_ERROR_MSG Tests
+
+
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_platform_overlay_available', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_oef_prompt_available', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_oef_update_prompt', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_prompt_available', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_metric_update_prompt', mock.Mock())
+def test_get_activation_error_alert_message_success(request_object):  # pylint: disable=redefined-outer-name
+    """
+    Test that get_global_alert_messages should return activation error message as the context when:
+        - request is not AJAX,
+        - user is authenticated,
+        - user is inactive,
+        - user is not requesting for activation
+    """
+
+    request = request_object
+    request.user.is_active = False
+
+    expected_global_alert_message = [
+        {
+            'type': ACTIVATION_ALERT_TYPE,
+            'alert': ACTIVATION_ERROR_MSG_FORMAT.format(
+                api_endpoint=reverse('resend_activation_email'),
+                user_id=request.user.id
+            )
+        }
+    ]
+
+    actual_global_alert_message = get_global_alert_messages(request).get('global_alert_messages')
+
+    assert expected_global_alert_message == actual_global_alert_message
+
+
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_platform_overlay_available', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_oef_prompt_available', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_oef_update_prompt', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_prompt_available', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_metric_update_prompt', mock.Mock())
+def test_get_activation_error_alert_message_ajax_failure(request_object):  # pylint: disable=redefined-outer-name
+    """
+    Test that get_global_alert_messages should NOT return activation error message as the context
+    when request is AJAX
+    """
+
+    request = request_object
+    request.user.is_active = False
+    request.META["HTTP_X_REQUESTED_WITH"] = "XMLHttpRequest"  # so request.is_ajax() == True
+
+    expected_global_alert_message = []
+    actual_global_alert_message = get_global_alert_messages(request).get('global_alert_messages')
+
+    assert expected_global_alert_message == actual_global_alert_message
+
+
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_platform_overlay_available', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_oef_prompt_available', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_oef_update_prompt', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_prompt_available', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_metric_update_prompt', mock.Mock())
+def test_get_activation_error_alert_message_auth_failure(request_object):  # pylint: disable=redefined-outer-name
+    """
+    Test that get_global_alert_messages should NOT return activation error message as the context
+    when user is unauthenticated
+    """
+
+    request = request_object
+    request.user = AnonymousUserFactory.create()  # AnonymousUserFactory creates an unauthenticated user
+    request.user.is_active = False
+
+    expected_global_alert_message = []
+    actual_global_alert_message = get_global_alert_messages(request).get('global_alert_messages')
+
+    assert expected_global_alert_message == actual_global_alert_message
+
+
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_platform_overlay_available', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_oef_prompt_available', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_oef_update_prompt', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_prompt_available', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_metric_update_prompt', mock.Mock())
+def test_get_activation_error_alert_message_active_user_failure(request_object):  # pylint: disable=redefined-outer-name
+    """
+    Test that get_global_alert_messages should NOT return activation error message as the context
+    when user is already active
+    """
+
+    request = request_object
+
+    expected_global_alert_message = []
+    actual_global_alert_message = get_global_alert_messages(request).get('global_alert_messages')
+
+    assert expected_global_alert_message == actual_global_alert_message
+
+
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_platform_overlay_available', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_oef_prompt_available', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_oef_update_prompt', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_prompt_available', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_metric_update_prompt', mock.Mock())
+def test_get_activation_error_alert_message_activation_url_failure(
+    request_object  # pylint: disable=redefined-outer-name
+):
+    """
+    Test that get_global_alert_messages should NOT return activation error message as the context
+    upon direction to the activation url, i.e. when request.path contains '/activate/'
+    """
+
+    request = request_object
+    request.user.is_active = False
+    request.path = request.path + '/activate/'  # append to url
+
+    expected_global_alert_message = []
+    actual_global_alert_message = get_global_alert_messages(request).get('global_alert_messages')
+
+    assert expected_global_alert_message == actual_global_alert_message
+
+# ORG_OEF_UPDATE_ALERT Tests
+
+
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_platform_overlay_available', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_oef_prompt_available')
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_oef_update_prompt')
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_prompt_available', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_metric_update_prompt', mock.Mock())
+def test_get_org_oef_update_alert_message_success(
+    mock_get_org_oef_update_prompt,
+    mock_is_org_oef_prompt_available,
+    request_object  # pylint: disable=redefined-outer-name
+):
+    """
+    Test that get_global_alert_messages returns ORG_OEF_UPDATE_ALERT as the context successfully when:
+        - oef_update_prompt = True,
+        - org_oef_prompt_available = True
+        - request.path contains '/oef/dashboard',
+    """
+
+    request = request_object
+    request.path = request.path + '/oef/dashboard'  # append to url
+
+    mock_get_org_oef_update_prompt.return_value = True
+    mock_is_org_oef_prompt_available.return_value = True
+
+    expected_global_alert_message = [
+        {
+            'type': ACTIVATION_ALERT_TYPE,
+            'alert': ORG_OEF_UPDATE_ALERT
+        }
+    ]
+    expected_oef_prompt = True
+
+    actual_result = get_global_alert_messages(request)
+    actual_global_alert_message = actual_result.get('global_alert_messages')
+    actual_oef_prompt = actual_result.get('oef_prompt')
+
+    assert expected_global_alert_message == actual_global_alert_message
+    assert expected_oef_prompt == actual_oef_prompt
+
+
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_platform_overlay_available', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_oef_prompt_available')
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_oef_update_prompt')
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_prompt_available', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_metric_update_prompt', mock.Mock())
+def test_get_org_oef_update_alert_message_oef_prompt_failure(
+    mock_get_org_oef_update_prompt,
+    mock_is_org_oef_prompt_available,
+    request_object  # pylint: disable=redefined-outer-name
+):
+    """
+    Test that get_global_alert_messages should NOT return ORG_OEF_UPDATE_ALERT as the context when:
+    oef_update_prompt = False
+    """
+
+    request = request_object
+    request.path = request.path + '/oef/dashboard'  # append to url
+
+    mock_get_org_oef_update_prompt.return_value = False
+    mock_is_org_oef_prompt_available.return_value = True
+
+    expected_global_alert_message = []
+    expected_oef_prompt = None
+
+    actual_result = get_global_alert_messages(request)
+    actual_global_alert_message = actual_result.get('global_alert_messages')
+    actual_oef_prompt = actual_result.get('oef_prompt')
+
+    assert expected_global_alert_message == actual_global_alert_message
+    assert expected_oef_prompt == actual_oef_prompt
+
+
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_platform_overlay_available', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_oef_prompt_available')
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_oef_update_prompt')
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_prompt_available', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_metric_update_prompt', mock.Mock())
+def test_get_org_oef_update_alert_message_oef_available_failure(
+    mock_get_org_oef_update_prompt,
+    mock_is_org_oef_prompt_available,
+    request_object  # pylint: disable=redefined-outer-name
+):
+    """
+    Test that get_global_alert_messages should NOT return ORG_OEF_UPDATE_ALERT as the contex twhen:
+    org_oef_prompt_available = False
+    """
+
+    request = request_object
+    request.path = request.path + '/oef/dashboard'  # append to url
+
+    mock_get_org_oef_update_prompt.return_value = True
+    mock_is_org_oef_prompt_available.return_value = False
+
+    expected_global_alert_message = []
+    expected_oef_prompt = None
+
+    actual_result = get_global_alert_messages(request)
+    actual_global_alert_message = actual_result.get('global_alert_messages')
+    actual_oef_prompt = actual_result.get('oef_prompt')
+
+    assert expected_global_alert_message == actual_global_alert_message
+    assert expected_oef_prompt == actual_oef_prompt
+
+
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_platform_overlay_available', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_oef_prompt_available')
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_oef_update_prompt')
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_prompt_available', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_metric_update_prompt', mock.Mock())
+def test_get_org_oef_update_alert_message_url_failure(
+    mock_get_org_oef_update_prompt,
+    mock_is_org_oef_prompt_available,
+    request_object  # pylint: disable=redefined-outer-name
+):
+    """
+    Test that get_global_alert_messages should NOT return ORG_OEF_UPDATE_ALERT as the context when:
+    '/oef/dashboard' is not part of the request url
+    """
+
+    request = request_object
+
+    mock_get_org_oef_update_prompt.return_value = True
+    mock_is_org_oef_prompt_available.return_value = True
+
+    expected_global_alert_message = []
+    expected_oef_prompt = None
+
+    actual_result = get_global_alert_messages(request)
+    actual_global_alert_message = actual_result.get('global_alert_messages')
+    actual_oef_prompt = actual_result.get('oef_prompt')
+
+    assert expected_global_alert_message == actual_global_alert_message
+    assert expected_oef_prompt == actual_oef_prompt
+
+# ORG_DETAILS_UPDATE_ALERT Tests
+
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_platform_overlay_available', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_oef_prompt_available', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_oef_update_prompt', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_prompt_available')
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_metric_update_prompt')
+def test_get_org_details_update_alert_message_success(
+    mock_get_org_metric_update_prompt,
+    mock_is_org_detail_prompt_available,
+    request_object  # pylint: disable=redefined-outer-name
+):
+    """
+    Test that get_global_alert_messages returns ORG_DETAILS_UPDATE_ALERT as the context successfully when:
+        - metric_update_prompt = True,
+        - org_detail_prompt_available = True
+        - request.path contains '/organization/details/',
+    """
+
+    request = request_object
+    request.path = request.path + '/organization/details/'  # append to url
+
+    mock_get_org_metric_update_prompt.return_value = True
+    mock_is_org_detail_prompt_available.return_value = True
+
+    expected_global_alert_message = [
+        {
+            'type': ACTIVATION_ALERT_TYPE,
+            'alert': ORG_DETAILS_UPDATE_ALERT
+        }
+    ]
+
+    actual_global_alert_message = get_global_alert_messages(request).get('global_alert_messages')
+
+    assert expected_global_alert_message == actual_global_alert_message
+
+
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_platform_overlay_available', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_oef_prompt_available', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_oef_update_prompt', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_prompt_available')
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_metric_update_prompt')
+def test_get_org_details_update_alert_message_metric_prompt_failure(
+    mock_get_org_metric_update_prompt,
+    mock_is_org_detail_prompt_available,
+    request_object  # pylint: disable=redefined-outer-name
+):
+    """
+    Test that get_global_alert_messages should NOT return ORG_DETAILS_UPDATE_ALERT as the context when:
+    metric_update_prompt = False
+    """
+
+    request = request_object
+    request.path = request.path + '/organization/details/'  # append to url
+
+    mock_get_org_metric_update_prompt.return_value = False
+    mock_is_org_detail_prompt_available.return_value = True
+
+    expected_global_alert_message = []
+    actual_global_alert_message = get_global_alert_messages(request).get('global_alert_messages')
+
+    assert expected_global_alert_message == actual_global_alert_message
+
+
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_platform_overlay_available', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_oef_prompt_available', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_oef_update_prompt', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_prompt_available')
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_metric_update_prompt')
+def test_get_org_details_update_alert_message_detail_prompt_failure(
+    mock_get_org_metric_update_prompt,
+    mock_is_org_detail_prompt_available,
+    request_object  # pylint: disable=redefined-outer-name
+):
+    """
+    Test that get_global_alert_messages should NOT return ORG_DETAILS_UPDATE_ALERT as the context when:
+    org_detail_prompt_available = False
+    """
+
+    request = request_object
+    request.path = request.path + '/organization/details/'  # append to url
+
+    mock_get_org_metric_update_prompt.return_value = True
+    mock_is_org_detail_prompt_available.return_value = False
+
+    expected_global_alert_message = []
+    actual_global_alert_message = get_global_alert_messages(request).get('global_alert_messages')
+
+    assert expected_global_alert_message == actual_global_alert_message
+
+
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_platform_overlay_available', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_oef_prompt_available', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_oef_update_prompt', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_prompt_available')
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_metric_update_prompt')
+def test_get_org_details_update_alert_message_url_failure(
+    mock_get_org_metric_update_prompt,
+    mock_is_org_detail_prompt_available,
+    request_object  # pylint: disable=redefined-outer-name
+):
+    """
+    Test that get_global_alert_messages should NOT return ORG_DETAILS_UPDATE_ALERT as the context when:
+    '/organization/details/' is not part of the request url
+    """
+
+    request = request_object
+
+    mock_get_org_metric_update_prompt.return_value = True
+    mock_is_org_detail_prompt_available.return_value = True
+
+    expected_global_alert_message = []
+    actual_global_alert_message = get_global_alert_messages(request).get('global_alert_messages')
+
+    assert expected_global_alert_message == actual_global_alert_message
+
+# Overlay Message Tests
+
+
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_platform_overlay_available')
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_oef_prompt_available', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_oef_update_prompt', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_prompt_available')
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_metric_update_prompt')
+def test_overlay_message_success(
+    mock_get_org_metric_update_prompt,
+    mock_is_org_detail_prompt_available,
+    mock_is_org_detail_platform_overlay_available,
+    request_object  # pylint: disable=redefined-outer-name
+):
+    """
+    Test that get_global_alert_messages returns overlay_message = True when:
+        - metric_update_prompt = True,
+        - org_detail_prompt_available = True,
+        - org_detail_platform_overlay_available = True,
+        - request.path does not contain '/oef/dashboard'
+        - request.path does not contain '/organization/details/'
+    """
+
+    request = request_object
+
+    mock_get_org_metric_update_prompt.return_value = True
+    mock_is_org_detail_prompt_available.return_value = True
+    mock_is_org_detail_platform_overlay_available.return_value = True
+
+    expected_overlay_message = True
+
+    actual_overlay_message = get_global_alert_messages(request).get('overlay_message')
+
+    assert expected_overlay_message == actual_overlay_message
+
+
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_platform_overlay_available')
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_oef_prompt_available', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_oef_update_prompt', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_prompt_available')
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_metric_update_prompt')
+def test_overlay_message_metric_prompt_failure(
+    mock_get_org_metric_update_prompt,
+    mock_is_org_detail_prompt_available,
+    mock_is_org_detail_platform_overlay_available,
+    request_object  # pylint: disable=redefined-outer-name
+):
+    """
+    Test that get_global_alert_messages returns overlay_message = None when metric_update_prompt = False
+    """
+
+    request = request_object
+
+    mock_get_org_metric_update_prompt.return_value = False
+    mock_is_org_detail_prompt_available.return_value = True
+    mock_is_org_detail_platform_overlay_available.return_value = True
+
+    expected_overlay_message = None
+    actual_overlay_message = get_global_alert_messages(request).get('overlay_message')
+
+    assert expected_overlay_message == actual_overlay_message
+
+
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_platform_overlay_available')
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_oef_prompt_available', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_oef_update_prompt', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_prompt_available')
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_metric_update_prompt')
+def test_overlay_message_detail_prompt_failure(
+    mock_get_org_metric_update_prompt,
+    mock_is_org_detail_prompt_available,
+    mock_is_org_detail_platform_overlay_available,
+    request_object  # pylint: disable=redefined-outer-name
+):
+    """
+    Test that get_global_alert_messages returns overlay_message = None when org_detail_prompt_available = False
+    """
+
+    request = request_object
+
+    mock_get_org_metric_update_prompt.return_value = True
+    mock_is_org_detail_prompt_available.return_value = False
+    mock_is_org_detail_platform_overlay_available.return_value = True
+
+    expected_overlay_message = None
+    actual_overlay_message = get_global_alert_messages(request).get('overlay_message')
+
+    assert expected_overlay_message == actual_overlay_message
+
+
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_platform_overlay_available')
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_oef_prompt_available', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_oef_update_prompt', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_prompt_available')
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_metric_update_prompt')
+def test_overlay_message_platform_overlay_failure(
+    mock_get_org_metric_update_prompt,
+    mock_is_org_detail_prompt_available,
+    mock_is_org_detail_platform_overlay_available,
+    request_object  # pylint: disable=redefined-outer-name
+):
+    """
+    Test that get_global_alert_messages returns overlay_message = None when
+    org_detail_platform_overlay_available = False
+    """
+
+    request = request_object
+
+    mock_get_org_metric_update_prompt.return_value = True
+    mock_is_org_detail_prompt_available.return_value = True
+    mock_is_org_detail_platform_overlay_available.return_value = False
+
+    expected_overlay_message = None
+    actual_overlay_message = get_global_alert_messages(request).get('overlay_message')
+
+    assert expected_overlay_message == actual_overlay_message
+
+
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_platform_overlay_available')
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_oef_prompt_available', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_oef_update_prompt', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_prompt_available')
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_metric_update_prompt')
+def test_overlay_message_oef_url_failure(
+    mock_get_org_metric_update_prompt,
+    mock_is_org_detail_prompt_available,
+    mock_is_org_detail_platform_overlay_available,
+    request_object  # pylint: disable=redefined-outer-name
+):
+    """
+    Test that get_global_alert_messages returns overlay_message = None when request.path contains '/oef/dashboard'
+    """
+
+    request = request_object
+    request.path = request.path + '/oef/dashboard'  # append to url
+
+    mock_get_org_metric_update_prompt.return_value = True
+    mock_is_org_detail_prompt_available.return_value = True
+    mock_is_org_detail_platform_overlay_available.return_value = True
+
+    expected_overlay_message = None
+    actual_overlay_message = get_global_alert_messages(request).get('overlay_message')
+
+    assert expected_overlay_message == actual_overlay_message
+
+
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_platform_overlay_available')
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_oef_prompt_available', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_oef_update_prompt', mock.Mock())
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_prompt_available')
+@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_metric_update_prompt')
+def test_overlay_message_org_url_failure(
+    mock_get_org_metric_update_prompt,
+    mock_is_org_detail_prompt_available,
+    mock_is_org_detail_platform_overlay_available,
+    request_object  # pylint: disable=redefined-outer-name
+):
+    """
+    Test that get_global_alert_messages returns overlay_message = None when request.path contains '/oef/dashboard'
+    """
+
+    request = request_object
+    request.path = request.path + '/organization/details/'  # append to url
+
+    mock_get_org_metric_update_prompt.return_value = True
+    mock_is_org_detail_prompt_available.return_value = True
+    mock_is_org_detail_platform_overlay_available.return_value = True
+
+    expected_overlay_message = None
+    actual_overlay_message = get_global_alert_messages(request).get('overlay_message')
+
+    assert expected_overlay_message == actual_overlay_message
+
+# Tests for other context processors
+
+
+def test_add_nodebb_endpoint():
+    request = 'request'
+    expected_result = {'nodebb_endpoint': settings.NODEBB_ENDPOINT}
+    actual_result = add_nodebb_endpoint(request)
+    assert expected_result == actual_result
+
+
+def test_get_cdn_link():
+    request = 'request'
+    expected_result = {'cdn_link': settings.CDN_LINK}
+    actual_result = get_cdn_link(request)
+    assert expected_result == actual_result

--- a/lms/djangoapps/philu_overrides/tests/test_context_processor.py
+++ b/lms/djangoapps/philu_overrides/tests/test_context_processor.py
@@ -1,590 +1,274 @@
 """
 Tests for context processors in philu_overrides
 """
+# pylint: disable=redefined-outer-name
 
-import mock
 import pytest
-from django.conf import settings
-from django.test import RequestFactory
-from django.urls import reverse
+from mock import Mock
 
 from lms.djangoapps.philu_overrides.constants import (
-    ACTIVATION_ALERT_TYPE,
-    ACTIVATION_ERROR_MSG_FORMAT,
-    ORG_DETAILS_UPDATE_ALERT,
-    ORG_OEF_UPDATE_ALERT
+    CDN_LINK_DICT,
+    NODEBB_END_POINT_DICT,
+    ORG_DETAILS_UPDATE_ALERT_MSG_DICT,
+    ORG_OEF_UPDATE_ALERT_MSG_DICT
 )
 from lms.djangoapps.philu_overrides.context_processor import (
     add_nodebb_endpoint,
     get_cdn_link,
     get_global_alert_messages
 )
+from lms.djangoapps.philu_overrides.helpers import get_activation_alert_error_msg_dict
 from student.tests.factories import AnonymousUserFactory, UserFactory
 
 
 @pytest.fixture()
-def request_object(db):  # pylint: disable=unused-argument
-    request = RequestFactory().get('/dummy_url')
+def request_obj(db, rf):  # pylint: disable=unused-argument
+    request = rf.get('/dummy_url')
     request.user = UserFactory.create()
     return request
 
-# Tests for get_global_alert_messages context processor
 
-# ACTIVATION_ERROR_MSG Tests
-
-
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_platform_overlay_available', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_oef_prompt_available', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_oef_update_prompt', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_prompt_available', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_metric_update_prompt', mock.Mock())
-def test_get_activation_error_alert_message_success(request_object):  # pylint: disable=redefined-outer-name
+def _mock_get_global_alert_messages_dependencies(
+    mocker,
+    is_org_detail_platform_overlay_available_return_value=Mock(),
+    is_org_oef_prompt_available_return_value=Mock(),
+    get_org_oef_update_prompt_return_value=Mock(),
+    is_org_detail_prompt_available_return_value=Mock(),
+    get_org_metric_update_prompt_return_value=Mock()
+):
     """
-    Test that get_global_alert_messages should return activation error message as the context when:
+    Mock all dependencies of the function 'get_global_alert_messages' at module level
+    """
+    mocker.patch(
+        'lms.djangoapps.philu_overrides.context_processor.is_org_detail_platform_overlay_available',
+        return_value=is_org_detail_platform_overlay_available_return_value,
+    )
+    mocker.patch(
+        'lms.djangoapps.philu_overrides.context_processor.is_org_oef_prompt_available',
+        return_value=is_org_oef_prompt_available_return_value,
+    )
+    mocker.patch(
+        'lms.djangoapps.philu_overrides.context_processor.get_org_oef_update_prompt',
+        return_value=get_org_oef_update_prompt_return_value
+    )
+    mocker.patch(
+        'lms.djangoapps.philu_overrides.context_processor.is_org_detail_prompt_available',
+        return_value=is_org_detail_prompt_available_return_value
+    )
+    mocker.patch(
+        'lms.djangoapps.philu_overrides.context_processor.get_org_metric_update_prompt',
+        return_value=get_org_metric_update_prompt_return_value
+    )
+
+
+@pytest.mark.parametrize(
+    'is_active, is_ajax, user, path_to_append, expected_global_alert_message',
+    [
+        pytest.param(False, False, None, None, 'get_activation_alert_error_msg_dict', id='success'),
+        pytest.param(False, True, None, None, [], id='ajax_failure'),
+        pytest.param(False, False, AnonymousUserFactory.create(), None, [], id='auth_failure'),
+        pytest.param(True, False, None, None, [], id='active_user_failure'),
+        pytest.param(False, False, None, '/activate/', [], id='activation_url_failure')
+    ]
+)
+def test_get_activation_error_alert_message(
+    is_active, is_ajax, user, path_to_append, expected_global_alert_message, request_obj, mocker
+):
+    """
+    Test success and all failure scenarios of activation error alert message
+
+    1. Test that get_global_alert_messages should successfully return activation error message as the context when:
         - request is not AJAX,
         - user is authenticated,
         - user is inactive,
         - user is not requesting for activation
+
+    2. Test that get_global_alert_messages should NOT return activation error message as the context when:
+        2.1. request is AJAX
+        2.2. user is unauthenticated
+        2.3. user is already active
+        2.4. user is directed to the activation url, i.e. when request.path contains '/activate/'
     """
+    _mock_get_global_alert_messages_dependencies(mocker)
 
-    request = request_object
-    request.user.is_active = False
+    request_obj.user.is_active = is_active
 
-    expected_global_alert_message = [
-        {
-            'type': ACTIVATION_ALERT_TYPE,
-            'alert': ACTIVATION_ERROR_MSG_FORMAT.format(
-                api_endpoint=reverse('resend_activation_email'),
-                user_id=request.user.id
-            )
-        }
+    if is_ajax:
+        request_obj.META['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest'
+
+    if user:
+        request_obj.user = user
+
+    if path_to_append:
+        request_obj.path += path_to_append
+
+    if expected_global_alert_message:
+        expected_global_alert_message = [get_activation_alert_error_msg_dict(request_obj.user.id)]
+
+    actual_global_alert_message = get_global_alert_messages(request_obj).get('global_alert_messages')
+
+    assert expected_global_alert_message == actual_global_alert_message
+
+
+@pytest.mark.parametrize(
+    'is_org_oef_prompt_available,'
+    'get_org_oef_update_prompt,'
+    'path_to_append,'
+    'expected_global_alert_message,'
+    'expected_oef_prompt',
+    [
+        pytest.param(True, True, '/oef/dashboard', [ORG_OEF_UPDATE_ALERT_MSG_DICT], True, id='success'),
+        pytest.param(True, False, '/oef/dashboard', [], None, id='oef_prompt_failure'),
+        pytest.param(False, True, '/oef/dashboard', [], None, id='oef_available_failure'),
+        pytest.param(True, True, None, [], None, id='url_failure'),
     ]
-
-    actual_global_alert_message = get_global_alert_messages(request).get('global_alert_messages')
-
-    assert expected_global_alert_message == actual_global_alert_message
-
-
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_platform_overlay_available', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_oef_prompt_available', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_oef_update_prompt', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_prompt_available', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_metric_update_prompt', mock.Mock())
-def test_get_activation_error_alert_message_ajax_failure(request_object):  # pylint: disable=redefined-outer-name
-    """
-    Test that get_global_alert_messages should NOT return activation error message as the context
-    when request is AJAX
-    """
-
-    request = request_object
-    request.user.is_active = False
-    request.META['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest'  # so request.is_ajax() == True
-
-    expected_global_alert_message = []
-    actual_global_alert_message = get_global_alert_messages(request).get('global_alert_messages')
-
-    assert expected_global_alert_message == actual_global_alert_message
-
-
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_platform_overlay_available', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_oef_prompt_available', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_oef_update_prompt', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_prompt_available', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_metric_update_prompt', mock.Mock())
-def test_get_activation_error_alert_message_auth_failure(request_object):  # pylint: disable=redefined-outer-name
-    """
-    Test that get_global_alert_messages should NOT return activation error message as the context
-    when user is unauthenticated
-    """
-
-    request = request_object
-    request.user = AnonymousUserFactory.create()  # AnonymousUserFactory creates an unauthenticated user
-    request.user.is_active = False
-
-    expected_global_alert_message = []
-    actual_global_alert_message = get_global_alert_messages(request).get('global_alert_messages')
-
-    assert expected_global_alert_message == actual_global_alert_message
-
-
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_platform_overlay_available', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_oef_prompt_available', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_oef_update_prompt', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_prompt_available', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_metric_update_prompt', mock.Mock())
-def test_get_activation_error_alert_message_active_user_failure(request_object):  # pylint: disable=redefined-outer-name
-    """
-    Test that get_global_alert_messages should NOT return activation error message as the context
-    when user is already active
-    """
-
-    request = request_object
-
-    expected_global_alert_message = []
-    actual_global_alert_message = get_global_alert_messages(request).get('global_alert_messages')
-
-    assert expected_global_alert_message == actual_global_alert_message
-
-
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_platform_overlay_available', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_oef_prompt_available', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_oef_update_prompt', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_prompt_available', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_metric_update_prompt', mock.Mock())
-def test_get_activation_error_alert_message_activation_url_failure(
-    request_object  # pylint: disable=redefined-outer-name
+)
+def test_get_org_oef_update_alert_message(
+    is_org_oef_prompt_available,
+    get_org_oef_update_prompt,
+    path_to_append,
+    expected_global_alert_message,
+    expected_oef_prompt,
+    request_obj,
+    mocker,
 ):
     """
-    Test that get_global_alert_messages should NOT return activation error message as the context
-    upon direction to the activation url, i.e. when request.path contains '/activate/'
-    """
+    Test success and all failure scenarios of ORG_OEF_UPDATE_ALERT message
 
-    request = request_object
-    request.user.is_active = False
-    request.path = request.path + '/activate/'
-
-    expected_global_alert_message = []
-    actual_global_alert_message = get_global_alert_messages(request).get('global_alert_messages')
-
-    assert expected_global_alert_message == actual_global_alert_message
-
-# ORG_OEF_UPDATE_ALERT Tests
-
-
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_platform_overlay_available', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_oef_prompt_available')
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_oef_update_prompt')
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_prompt_available', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_metric_update_prompt', mock.Mock())
-def test_get_org_oef_update_alert_message_success(
-    mock_get_org_oef_update_prompt,
-    mock_is_org_oef_prompt_available,
-    request_object  # pylint: disable=redefined-outer-name
-):
-    """
-    Test that get_global_alert_messages returns ORG_OEF_UPDATE_ALERT as the context successfully when:
+    1. Test that get_global_alert_messages returns ORG_OEF_UPDATE_ALERT as the context successfully when:
         - oef_update_prompt = True,
         - org_oef_prompt_available = True
-        - request.path contains '/oef/dashboard',
+        - request.path contains '/oef/dashboard'
+
+    2. Test that get_global_alert_messages should NOT return ORG_OEF_UPDATE_ALERT as the context when:
+        2.1. oef_update_prompt = False
+        2.2. org_oef_prompt_available = False
+        2.3. '/oef/dashboard' is not part of the request url
     """
+    _mock_get_global_alert_messages_dependencies(
+        mocker,
+        is_org_oef_prompt_available_return_value=is_org_oef_prompt_available,
+        get_org_oef_update_prompt_return_value=get_org_oef_update_prompt
+    )
 
-    request = request_object
-    request.path = request.path + '/oef/dashboard'
+    if path_to_append:
+        request_obj.path += path_to_append
 
-    mock_get_org_oef_update_prompt.return_value = True
-    mock_is_org_oef_prompt_available.return_value = True
+    actual_result = get_global_alert_messages(request_obj)
+    actual_global_alert_message = actual_result.get('global_alert_messages')
+    actual_oef_prompt = actual_result.get('oef_prompt')
 
-    expected_global_alert_message = [
-        {
-            'type': ACTIVATION_ALERT_TYPE,
-            'alert': ORG_OEF_UPDATE_ALERT
-        }
+    assert expected_global_alert_message == actual_global_alert_message
+    assert expected_oef_prompt == actual_oef_prompt
+
+
+@pytest.mark.parametrize(
+    'is_org_detail_prompt_available, get_org_metric_update_prompt, path_to_append, expected_global_alert_message',
+    [
+        pytest.param(True, True, '/organization/details/', [ORG_DETAILS_UPDATE_ALERT_MSG_DICT], id='success'),
+        pytest.param(True, False, '/organization/details/', [], id='metric_prompt_failure'),
+        pytest.param(False, True, '/organization/details/', [], id='detail_prompt_failure'),
+        pytest.param(True, True, None, [], id='url_failure')
     ]
-    expected_oef_prompt = True
-
-    actual_result = get_global_alert_messages(request)
-    actual_global_alert_message = actual_result.get('global_alert_messages')
-    actual_oef_prompt = actual_result.get('oef_prompt')
-
-    assert expected_global_alert_message == actual_global_alert_message
-    assert expected_oef_prompt == actual_oef_prompt
-
-
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_platform_overlay_available', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_oef_prompt_available')
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_oef_update_prompt')
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_prompt_available', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_metric_update_prompt', mock.Mock())
-def test_get_org_oef_update_alert_message_oef_prompt_failure(
-    mock_get_org_oef_update_prompt,
-    mock_is_org_oef_prompt_available,
-    request_object  # pylint: disable=redefined-outer-name
+)
+def test_get_org_details_update_alert_message(
+    is_org_detail_prompt_available,
+    get_org_metric_update_prompt,
+    path_to_append,
+    expected_global_alert_message,
+    request_obj,
+    mocker,
 ):
     """
-    Test that get_global_alert_messages should NOT return ORG_OEF_UPDATE_ALERT as the context when:
-    oef_update_prompt = False
-    """
+    Test success and all failure scenarios of ORG_DETAILS_UPDATE_ALERT message
 
-    request = request_object
-    request.path = request.path + '/oef/dashboard'
-
-    mock_get_org_oef_update_prompt.return_value = False
-    mock_is_org_oef_prompt_available.return_value = True
-
-    expected_global_alert_message = []
-    expected_oef_prompt = None
-
-    actual_result = get_global_alert_messages(request)
-    actual_global_alert_message = actual_result.get('global_alert_messages')
-    actual_oef_prompt = actual_result.get('oef_prompt')
-
-    assert expected_global_alert_message == actual_global_alert_message
-    assert expected_oef_prompt == actual_oef_prompt
-
-
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_platform_overlay_available', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_oef_prompt_available')
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_oef_update_prompt')
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_prompt_available', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_metric_update_prompt', mock.Mock())
-def test_get_org_oef_update_alert_message_oef_available_failure(
-    mock_get_org_oef_update_prompt,
-    mock_is_org_oef_prompt_available,
-    request_object  # pylint: disable=redefined-outer-name
-):
-    """
-    Test that get_global_alert_messages should NOT return ORG_OEF_UPDATE_ALERT as the contex twhen:
-    org_oef_prompt_available = False
-    """
-
-    request = request_object
-    request.path = request.path + '/oef/dashboard'
-
-    mock_get_org_oef_update_prompt.return_value = True
-    mock_is_org_oef_prompt_available.return_value = False
-
-    expected_global_alert_message = []
-    expected_oef_prompt = None
-
-    actual_result = get_global_alert_messages(request)
-    actual_global_alert_message = actual_result.get('global_alert_messages')
-    actual_oef_prompt = actual_result.get('oef_prompt')
-
-    assert expected_global_alert_message == actual_global_alert_message
-    assert expected_oef_prompt == actual_oef_prompt
-
-
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_platform_overlay_available', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_oef_prompt_available')
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_oef_update_prompt')
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_prompt_available', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_metric_update_prompt', mock.Mock())
-def test_get_org_oef_update_alert_message_url_failure(
-    mock_get_org_oef_update_prompt,
-    mock_is_org_oef_prompt_available,
-    request_object  # pylint: disable=redefined-outer-name
-):
-    """
-    Test that get_global_alert_messages should NOT return ORG_OEF_UPDATE_ALERT as the context when:
-    '/oef/dashboard' is not part of the request url
-    """
-
-    request = request_object
-
-    mock_get_org_oef_update_prompt.return_value = True
-    mock_is_org_oef_prompt_available.return_value = True
-
-    expected_global_alert_message = []
-    expected_oef_prompt = None
-
-    actual_result = get_global_alert_messages(request)
-    actual_global_alert_message = actual_result.get('global_alert_messages')
-    actual_oef_prompt = actual_result.get('oef_prompt')
-
-    assert expected_global_alert_message == actual_global_alert_message
-    assert expected_oef_prompt == actual_oef_prompt
-
-# ORG_DETAILS_UPDATE_ALERT Tests
-
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_platform_overlay_available', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_oef_prompt_available', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_oef_update_prompt', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_prompt_available')
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_metric_update_prompt')
-def test_get_org_details_update_alert_message_success(
-    mock_get_org_metric_update_prompt,
-    mock_is_org_detail_prompt_available,
-    request_object  # pylint: disable=redefined-outer-name
-):
-    """
-    Test that get_global_alert_messages returns ORG_DETAILS_UPDATE_ALERT as the context successfully when:
+    1. Test that get_global_alert_messages returns ORG_DETAILS_UPDATE_ALERT as the context successfully when:
         - metric_update_prompt = True,
         - org_detail_prompt_available = True
-        - request.path contains '/organization/details/',
+        - request.path contains '/organization/details/'
+
+    2. Test that get_global_alert_messages should NOT return ORG_DETAILS_UPDATE_ALERT as the context when:
+        2.1. metric_update_prompt = False
+        2.2. org_detail_prompt_available = False
+        2.3. '/organization/details/' is not part of the request url
     """
+    _mock_get_global_alert_messages_dependencies(
+        mocker,
+        is_org_detail_prompt_available_return_value=is_org_detail_prompt_available,
+        get_org_metric_update_prompt_return_value=get_org_metric_update_prompt
+    )
 
-    request = request_object
-    request.path = request.path + '/organization/details/'
+    if path_to_append:
+        request_obj.path += path_to_append
 
-    mock_get_org_metric_update_prompt.return_value = True
-    mock_is_org_detail_prompt_available.return_value = True
+    actual_global_alert_message = get_global_alert_messages(request_obj).get('global_alert_messages')
 
-    expected_global_alert_message = [
-        {
-            'type': ACTIVATION_ALERT_TYPE,
-            'alert': ORG_DETAILS_UPDATE_ALERT
-        }
+    assert expected_global_alert_message == actual_global_alert_message
+
+
+@pytest.mark.parametrize(
+    'is_org_detail_platform_overlay_available,'
+    'is_org_detail_prompt_available,'
+    'get_org_metric_update_prompt,'
+    'path_to_append,'
+    'expected_overlay_message',
+    [
+        pytest.param(True, True, True, None, True, id='success'),
+        pytest.param(True, True, False, None, None, id='metric_prompt_failure'),
+        pytest.param(True, False, True, None, None, id='detail_prompt_failure'),
+        pytest.param(False, True, True, None, None, id='platform_overlay_failure'),
+        pytest.param(True, True, True, '/oef/dashboard', None, id='oef_url_failure'),
+        pytest.param(True, True, True, '/organization/details/', None, id='org_url_failure')
     ]
-
-    actual_global_alert_message = get_global_alert_messages(request).get('global_alert_messages')
-
-    assert expected_global_alert_message == actual_global_alert_message
-
-
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_platform_overlay_available', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_oef_prompt_available', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_oef_update_prompt', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_prompt_available')
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_metric_update_prompt')
-def test_get_org_details_update_alert_message_metric_prompt_failure(
-    mock_get_org_metric_update_prompt,
-    mock_is_org_detail_prompt_available,
-    request_object  # pylint: disable=redefined-outer-name
+)
+def test_overlay_message(
+    is_org_detail_platform_overlay_available,
+    is_org_detail_prompt_available,
+    get_org_metric_update_prompt,
+    path_to_append,
+    expected_overlay_message,
+    request_obj,
+    mocker
 ):
     """
-    Test that get_global_alert_messages should NOT return ORG_DETAILS_UPDATE_ALERT as the context when:
-    metric_update_prompt = False
-    """
+    Test success and all failure scenarios of overlay_message flag
 
-    request = request_object
-    request.path = request.path + '/organization/details/'
-
-    mock_get_org_metric_update_prompt.return_value = False
-    mock_is_org_detail_prompt_available.return_value = True
-
-    expected_global_alert_message = []
-    actual_global_alert_message = get_global_alert_messages(request).get('global_alert_messages')
-
-    assert expected_global_alert_message == actual_global_alert_message
-
-
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_platform_overlay_available', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_oef_prompt_available', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_oef_update_prompt', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_prompt_available')
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_metric_update_prompt')
-def test_get_org_details_update_alert_message_detail_prompt_failure(
-    mock_get_org_metric_update_prompt,
-    mock_is_org_detail_prompt_available,
-    request_object  # pylint: disable=redefined-outer-name
-):
-    """
-    Test that get_global_alert_messages should NOT return ORG_DETAILS_UPDATE_ALERT as the context when:
-    org_detail_prompt_available = False
-    """
-
-    request = request_object
-    request.path = request.path + '/organization/details/'
-
-    mock_get_org_metric_update_prompt.return_value = True
-    mock_is_org_detail_prompt_available.return_value = False
-
-    expected_global_alert_message = []
-    actual_global_alert_message = get_global_alert_messages(request).get('global_alert_messages')
-
-    assert expected_global_alert_message == actual_global_alert_message
-
-
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_platform_overlay_available', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_oef_prompt_available', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_oef_update_prompt', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_prompt_available')
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_metric_update_prompt')
-def test_get_org_details_update_alert_message_url_failure(
-    mock_get_org_metric_update_prompt,
-    mock_is_org_detail_prompt_available,
-    request_object  # pylint: disable=redefined-outer-name
-):
-    """
-    Test that get_global_alert_messages should NOT return ORG_DETAILS_UPDATE_ALERT as the context when:
-    '/organization/details/' is not part of the request url
-    """
-
-    request = request_object
-
-    mock_get_org_metric_update_prompt.return_value = True
-    mock_is_org_detail_prompt_available.return_value = True
-
-    expected_global_alert_message = []
-    actual_global_alert_message = get_global_alert_messages(request).get('global_alert_messages')
-
-    assert expected_global_alert_message == actual_global_alert_message
-
-# Overlay Message Tests
-
-
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_platform_overlay_available')
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_oef_prompt_available', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_oef_update_prompt', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_prompt_available')
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_metric_update_prompt')
-def test_overlay_message_success(
-    mock_get_org_metric_update_prompt,
-    mock_is_org_detail_prompt_available,
-    mock_is_org_detail_platform_overlay_available,
-    request_object  # pylint: disable=redefined-outer-name
-):
-    """
-    Test that get_global_alert_messages returns overlay_message = True when:
+    1. Test that get_global_alert_messages returns overlay_message = True when:
         - metric_update_prompt = True,
         - org_detail_prompt_available = True,
         - org_detail_platform_overlay_available = True,
         - request.path does not contain '/oef/dashboard'
         - request.path does not contain '/organization/details/'
+
+    2. Test that get_global_alert_messages returns overlay_message = None when:
+        2.1. metric_update_prompt = False
+        2.2. org_detail_prompt_available = False
+        2.3. org_detail_platform_overlay_available = False
+        2.4. request.path contains '/oef/dashboard'
+        2.5. request.path contains '/organization/details/'
     """
+    _mock_get_global_alert_messages_dependencies(
+        mocker,
+        is_org_detail_platform_overlay_available_return_value=is_org_detail_platform_overlay_available,
+        is_org_detail_prompt_available_return_value=is_org_detail_prompt_available,
+        get_org_metric_update_prompt_return_value=get_org_metric_update_prompt
+    )
 
-    request = request_object
+    if path_to_append:
+        request_obj.path += path_to_append
 
-    mock_get_org_metric_update_prompt.return_value = True
-    mock_is_org_detail_prompt_available.return_value = True
-    mock_is_org_detail_platform_overlay_available.return_value = True
-
-    expected_overlay_message = True
-
-    actual_overlay_message = get_global_alert_messages(request).get('overlay_message')
+    actual_overlay_message = get_global_alert_messages(request_obj).get('overlay_message')
 
     assert expected_overlay_message == actual_overlay_message
-
-
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_platform_overlay_available')
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_oef_prompt_available', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_oef_update_prompt', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_prompt_available')
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_metric_update_prompt')
-def test_overlay_message_metric_prompt_failure(
-    mock_get_org_metric_update_prompt,
-    mock_is_org_detail_prompt_available,
-    mock_is_org_detail_platform_overlay_available,
-    request_object  # pylint: disable=redefined-outer-name
-):
-    """
-    Test that get_global_alert_messages returns overlay_message = None when metric_update_prompt = False
-    """
-
-    request = request_object
-
-    mock_get_org_metric_update_prompt.return_value = False
-    mock_is_org_detail_prompt_available.return_value = True
-    mock_is_org_detail_platform_overlay_available.return_value = True
-
-    expected_overlay_message = None
-    actual_overlay_message = get_global_alert_messages(request).get('overlay_message')
-
-    assert expected_overlay_message == actual_overlay_message
-
-
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_platform_overlay_available')
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_oef_prompt_available', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_oef_update_prompt', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_prompt_available')
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_metric_update_prompt')
-def test_overlay_message_detail_prompt_failure(
-    mock_get_org_metric_update_prompt,
-    mock_is_org_detail_prompt_available,
-    mock_is_org_detail_platform_overlay_available,
-    request_object  # pylint: disable=redefined-outer-name
-):
-    """
-    Test that get_global_alert_messages returns overlay_message = None when org_detail_prompt_available = False
-    """
-
-    request = request_object
-
-    mock_get_org_metric_update_prompt.return_value = True
-    mock_is_org_detail_prompt_available.return_value = False
-    mock_is_org_detail_platform_overlay_available.return_value = True
-
-    expected_overlay_message = None
-    actual_overlay_message = get_global_alert_messages(request).get('overlay_message')
-
-    assert expected_overlay_message == actual_overlay_message
-
-
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_platform_overlay_available')
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_oef_prompt_available', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_oef_update_prompt', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_prompt_available')
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_metric_update_prompt')
-def test_overlay_message_platform_overlay_failure(
-    mock_get_org_metric_update_prompt,
-    mock_is_org_detail_prompt_available,
-    mock_is_org_detail_platform_overlay_available,
-    request_object  # pylint: disable=redefined-outer-name
-):
-    """
-    Test that get_global_alert_messages returns overlay_message = None when
-    org_detail_platform_overlay_available = False
-    """
-
-    request = request_object
-
-    mock_get_org_metric_update_prompt.return_value = True
-    mock_is_org_detail_prompt_available.return_value = True
-    mock_is_org_detail_platform_overlay_available.return_value = False
-
-    expected_overlay_message = None
-    actual_overlay_message = get_global_alert_messages(request).get('overlay_message')
-
-    assert expected_overlay_message == actual_overlay_message
-
-
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_platform_overlay_available')
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_oef_prompt_available', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_oef_update_prompt', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_prompt_available')
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_metric_update_prompt')
-def test_overlay_message_oef_url_failure(
-    mock_get_org_metric_update_prompt,
-    mock_is_org_detail_prompt_available,
-    mock_is_org_detail_platform_overlay_available,
-    request_object  # pylint: disable=redefined-outer-name
-):
-    """
-    Test that get_global_alert_messages returns overlay_message = None when request.path contains '/oef/dashboard'
-    """
-
-    request = request_object
-    request.path = request.path + '/oef/dashboard'
-
-    mock_get_org_metric_update_prompt.return_value = True
-    mock_is_org_detail_prompt_available.return_value = True
-    mock_is_org_detail_platform_overlay_available.return_value = True
-
-    expected_overlay_message = None
-    actual_overlay_message = get_global_alert_messages(request).get('overlay_message')
-
-    assert expected_overlay_message == actual_overlay_message
-
-
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_platform_overlay_available')
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_oef_prompt_available', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_oef_update_prompt', mock.Mock())
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.is_org_detail_prompt_available')
-@mock.patch('lms.djangoapps.philu_overrides.context_processor.get_org_metric_update_prompt')
-def test_overlay_message_org_url_failure(
-    mock_get_org_metric_update_prompt,
-    mock_is_org_detail_prompt_available,
-    mock_is_org_detail_platform_overlay_available,
-    request_object  # pylint: disable=redefined-outer-name
-):
-    """
-    Test that get_global_alert_messages returns overlay_message = None when request.path contains '/oef/dashboard'
-    """
-
-    request = request_object
-    request.path = request.path + '/organization/details/'
-
-    mock_get_org_metric_update_prompt.return_value = True
-    mock_is_org_detail_prompt_available.return_value = True
-    mock_is_org_detail_platform_overlay_available.return_value = True
-
-    expected_overlay_message = None
-    actual_overlay_message = get_global_alert_messages(request).get('overlay_message')
-
-    assert expected_overlay_message == actual_overlay_message
-
-# Tests for other context processors
 
 
 def test_add_nodebb_endpoint():
-    request = 'request'
-    expected_result = {'nodebb_endpoint': settings.NODEBB_ENDPOINT}
-    actual_result = add_nodebb_endpoint(request)
+    expected_result = NODEBB_END_POINT_DICT
+    actual_result = add_nodebb_endpoint('request')
     assert expected_result == actual_result
 
 
 def test_get_cdn_link():
-    request = 'request'
-    expected_result = {'cdn_link': settings.CDN_LINK}
-    actual_result = get_cdn_link(request)
+    expected_result = CDN_LINK_DICT
+    actual_result = get_cdn_link('request')
     assert expected_result == actual_result

--- a/lms/djangoapps/philu_overrides/tests/test_context_processor.py
+++ b/lms/djangoapps/philu_overrides/tests/test_context_processor.py
@@ -78,9 +78,9 @@ def test_get_activation_error_alert_message(
     Test success and all failure scenarios of activation error alert message
 
     1. Test that get_global_alert_messages should successfully return activation error message as the context when:
-        - request is not AJAX,
-        - user is authenticated,
-        - user is inactive,
+        - request is not AJAX and
+        - user is authenticated and
+        - user is inactive and
         - user is not requesting for activation
 
     2. Test that get_global_alert_messages should NOT return activation error message as the context when:
@@ -136,8 +136,8 @@ def test_get_org_oef_update_alert_message(
     Test success and all failure scenarios of ORG_OEF_UPDATE_ALERT message
 
     1. Test that get_global_alert_messages returns ORG_OEF_UPDATE_ALERT as the context successfully when:
-        - oef_update_prompt = True,
-        - org_oef_prompt_available = True
+        - oef_update_prompt = True and
+        - org_oef_prompt_available = True and
         - request.path contains '/oef/dashboard'
 
     2. Test that get_global_alert_messages should NOT return ORG_OEF_UPDATE_ALERT as the context when:
@@ -183,8 +183,8 @@ def test_get_org_details_update_alert_message(
     Test success and all failure scenarios of ORG_DETAILS_UPDATE_ALERT message
 
     1. Test that get_global_alert_messages returns ORG_DETAILS_UPDATE_ALERT as the context successfully when:
-        - metric_update_prompt = True,
-        - org_detail_prompt_available = True
+        - metric_update_prompt = True and
+        - org_detail_prompt_available = True and
         - request.path contains '/organization/details/'
 
     2. Test that get_global_alert_messages should NOT return ORG_DETAILS_UPDATE_ALERT as the context when:
@@ -234,10 +234,10 @@ def test_overlay_message(
     Test success and all failure scenarios of overlay_message flag
 
     1. Test that get_global_alert_messages returns overlay_message = True when:
-        - metric_update_prompt = True,
-        - org_detail_prompt_available = True,
-        - org_detail_platform_overlay_available = True,
-        - request.path does not contain '/oef/dashboard'
+        - metric_update_prompt = True and
+        - org_detail_prompt_available = True and
+        - org_detail_platform_overlay_available = True and
+        - request.path does not contain '/oef/dashboard' and
         - request.path does not contain '/organization/details/'
 
     2. Test that get_global_alert_messages returns overlay_message = None when:

--- a/requirements/philu/base.txt
+++ b/requirements/philu/base.txt
@@ -12,3 +12,4 @@ img2pdf==0.2.4
 -e git+https://github.com/philanthropy-u/edx-notifications.git@9c602923d0e8a7b512a52bc4d0df5c7043286386#egg=edx-notifications
 git+https://github.com/philanthropy-u/openedx-scorm-xblock.git@master#egg=openedx-scorm-xblock
 django-multiselectfield==0.1.12
+pytest-mock==2.0.0

--- a/requirements/philu/testing.txt
+++ b/requirements/philu/testing.txt
@@ -11,6 +11,7 @@ img2pdf==0.2.4
 -e git+https://github.com/philanthropy-u/xblock-poll#egg=xblock-poll
 -e git+https://github.com/philanthropy-u/edx-notifications.git@9c602923d0e8a7b512a52bc4d0df5c7043286386#egg=edx-notifications
 django-multiselectfield==0.1.12
+pytest-mock==2.0.0
 # Downgrading following packages back to edX's versions as 'channels' has upgraded them.
 cryptography==2.4.2
 attrs==17.4.0


### PR DESCRIPTION
### Description

[LP-2254](https://philanthropyu.atlassian.net/browse/LP-2254)

### Notes

This PR contains pytests and hence pylint produced some unexpected warnings, which had to be suppresed.

- After the `request_object` fixture prototype in test_context_processor.py, I have suppressed the pylint warning: `unused-argument`. `db` is not explicitly used in `request_object` and thus pylint gives a warning, but it must be passed as a fixture, otherwise database access is not allowed inside the `request_object` method.

- After every test method argument of `request_object`, I have suppressed the following pylint warning: `redefined-outer-name`. `request_object` is to be passed as a fixture to the test methods so that the methods can access the request object. Maybe pylint is not mature enough to recognize fixture passing at this point.

Pylint report after suppressing the above mentioned warnings:

-------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 8.90/10, +1.10)