### PR TITLE
LP-2303 Fixing inconsistent usage_key in ORA command

### DIFF
--- a/openedx/features/philu_utils/utils.py
+++ b/openedx/features/philu_utils/utils.py
@@ -34,6 +34,6 @@ def get_anonymous_user(user, course_id):
         from student.models import AnonymousUserId
         return AnonymousUserId.objects.get(user=user, course_id=course_id)
     except AnonymousUserId.DoesNotExist:
-        log.info('Anonymous Id does not exist for User: {user}'.format(user=user))
+        log.info('Anonymous Id does not exist for User: {user} & Course: {course}'.format(user=user, course=course_id))
     except AnonymousUserId.MultipleObjectsReturned:
-        log.info('Multiple Anonymous Ids for User: {user}'.format(user=user))
+        log.info('Multiple Anonymous Ids for User: {user} & Course: {course}'.format(user=user, course=course_id))


### PR DESCRIPTION
### Description

[LP-2303](https://philanthropyu.atlassian.net/browse/LP-2303) Auto score ORA command

**Notes**

It was assumed that method `get_rubric_from_ora` was getting `usage_key` param as an object, but in actual `usage_key` was passed as a string. Though, in unit tests, `get_rubric_from_ora` method was getting `usage_key` as object, which is why unit-tests were passing.

So, now `usage_key` string is converted to object explicitly, inside `get_rubric_from_ora` method, and unit tests are updated accordingly.

