### PR TITLE
LP-2303 Fixing datetime inconsistency in delta and created at

### DIFF
--- a/openedx/features/assessment/constants.py
+++ b/openedx/features/assessment/constants.py
@@ -3,4 +3,4 @@ All constants for openassessment
 """
 DAYS_TO_WAIT_AUTO_ASSESSMENT = 3
 ORA_BLOCK_TYPE = 'openassessment'
-NO_PENDING_ORA = 'No pending open assessment found to autoscore, since last {days} days, from {since_date}'
+NO_PENDING_ORA = 'No pending open assessment found to autoscore, since last {days} days, from {since}'


### PR DESCRIPTION
### Description

[LP-2303](https://philanthropyu.atlassian.net/browse/LP-2303) ORA auto score command

[philu-edx-theme PR](https://github.com/philanthropy-u/philu-edx-theme/pull/###)

The delta calculated from current DateTime and ORA number of day to wait was taken as date (instead of DateTime) and was compared to the date value of `created_at`. It was working fine on local but was not working on the dev server.

Now all dates `delta` and `crrated_at` are compared as UTC DateTime. This works on both servers, local and dev.


### Notes

- Unit test updated
- All unit test are passing