### PR TITLE
mute pre and post save in UserFactory

### DIFF
--- a/common/djangoapps/student/tests/factories.py
+++ b/common/djangoapps/student/tests/factories.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 import factory
 from django.contrib.auth.models import AnonymousUser, Group, Permission
 from django.contrib.contenttypes.models import ContentType
+from django.db.models import signals
 from factory.django import DjangoModelFactory
 from opaque_keys.edx.keys import CourseKey
 from pytz import UTC
@@ -70,6 +71,7 @@ class RegistrationFactory(DjangoModelFactory):
     activation_key = uuid4().hex.decode('ascii')
 
 
+@factory.django.mute_signals(signals.pre_save, signals.post_save)
 class UserFactory(DjangoModelFactory):
     class Meta(object):
         model = User

--- a/scripts/unit-tests.sh
+++ b/scripts/unit-tests.sh
@@ -155,7 +155,6 @@ case "${TEST_SUITE}" in
             "common/djangoapps/mailchimp_pipeline/"
             "common/djangoapps/nodebb/"
             "common/djangoapps/philu_commands/"
-            "common/djangoapps/philu_commands/"
             "common/lib/discovery_client/"
             "common/lib/mandrill_client/"
             "common/lib/nodebb_client/"
@@ -168,6 +167,6 @@ case "${TEST_SUITE}" in
             "lms/djangoapps/student_dashboard/"
         )
         philu_apps_str="${philu_apps_list[@]}"
-        paver test_system -s lms -t "${philu_apps_str}" ${PAVER_ARGS} ${PARALLEL} 2> philu-tests.log
+        paver test_system -s lms -t "${philu_apps_str}" -v --processes=-1 2> philu-tests.log
         mv reports/.coverage reports/.coverage.philu
 esac


### PR DESCRIPTION
### Description

A lot of philu test cases are failing due to third party calls made in post_save of User. Disabling post and pre save signals to avoid those third party calls. 
