### PR TITLE
LP-2273 Fixing linting issues in custom settings

### DIFF
--- a/common/djangoapps/custom_settings/__init__.py
+++ b/common/djangoapps/custom_settings/__init__.py
@@ -1,1 +1,5 @@
+"""
+The custom settings app is a part of course settings in studio, which control specific course functionality. Course
+author can edit manual policies, which are JSON-based key and value pairs that control specific course settings.
+"""
 default_app_config = 'custom_settings.apps.CustomSettingsConfig'

--- a/common/djangoapps/custom_settings/admin.py
+++ b/common/djangoapps/custom_settings/admin.py
@@ -1,3 +1,6 @@
+"""
+Admin configuration for custom settings app models
+"""
 from django.contrib import admin
 
 from .models import CustomSettings

--- a/common/djangoapps/custom_settings/admin.py
+++ b/common/djangoapps/custom_settings/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+
 from .models import CustomSettings
 
 admin.site.register(CustomSettings)

--- a/common/djangoapps/custom_settings/apps.py
+++ b/common/djangoapps/custom_settings/apps.py
@@ -1,3 +1,6 @@
+"""
+Custom settings app configurations
+"""
 from django.apps import AppConfig
 
 
@@ -8,4 +11,4 @@ class CustomSettingsConfig(AppConfig):
         """
         Connect signal handlers.
         """
-        import custom_settings.signals.handlers
+        import custom_settings.signals.handlers  # pylint: disable=unused-variable

--- a/common/djangoapps/custom_settings/helpers.py
+++ b/common/djangoapps/custom_settings/helpers.py
@@ -1,3 +1,6 @@
+"""
+All helpers for custom settings app
+"""
 from datetime import datetime
 
 import pytz
@@ -9,23 +12,29 @@ DATE_FORMAT = "%m/%d/%Y"
 
 def get_course_open_date_from_settings(settings):
     """
-    :param settings:
-    :return course open date:
+    Get course open date from settings, if exists, in MM/DD/YYY format else return empty string
+
+    Args:
+        settings (CustomSettings): Custom settings model object
+
+    Returns:
+        string: Date in MM/DD/YYYY format or empty string
     """
-    return "" if not settings.course_open_date else settings.course_open_date.strftime(DATE_FORMAT)
+    return '' if not settings.course_open_date else settings.course_open_date.strftime(DATE_FORMAT)
 
 
 def validate_course_open_date(settings, course_open_date):
-
     """
-    this method compares course start date and course open date
-    and make sure that course open date is greater than start date
-    :param settings:
-    :param course_open_date:
-    :return:
-        validated course open date or none
-    """
+    This method compares course start date and course open date and make sure that course open date is greater
+    than start date
 
+    Args:
+        settings (CustomSettings): Custom settings model object
+        course_open_date (Date): Course open date
+
+    Returns:
+        Date: Validated course open date or None
+    """
     if course_open_date:
         if isinstance(datetime.strptime(course_open_date, DATE_FORMAT), datetime):
             course_open_date = datetime.strptime(course_open_date, DATE_FORMAT)

--- a/common/djangoapps/custom_settings/helpers.py
+++ b/common/djangoapps/custom_settings/helpers.py
@@ -1,5 +1,7 @@
-import pytz
 from datetime import datetime
+
+import pytz
+
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 
 DATE_FORMAT = "%m/%d/%Y"

--- a/common/djangoapps/custom_settings/models.py
+++ b/common/djangoapps/custom_settings/models.py
@@ -1,3 +1,6 @@
+"""
+All models for custom settings
+"""
 import json
 
 from django.db import models
@@ -26,7 +29,7 @@ class CustomSettings(models.Model):
     def __unicode__(self):
         return '{} | {}'.format(self.id, self.is_featured)
 
-    def save(self, *args, **kwargs):
+    def save(self, *args, **kwargs):  # pylint: disable=arguments-differ
         # This means that the model isn't saved to the database yet
         if self._state.adding and not self.course_short_id:
             # Get the maximum course_short_id value from the database
@@ -45,8 +48,10 @@ class CustomSettings(models.Model):
 
     def get_course_meta_tags(self):
         """
-        :return:
-            get seo tags for course
+        Extract and get course meta tags from seo_tags, if seo_tags is empty return empty course meta tags
+
+        Returns:
+            dict: Course meta tags
         """
         title, description, keywords, robots, utm_params = "", "", "", "", {}
         if self.seo_tags:

--- a/common/djangoapps/custom_settings/signals/handlers.py
+++ b/common/djangoapps/custom_settings/signals/handlers.py
@@ -1,3 +1,6 @@
+"""
+All handlers for custom settings app
+"""
 from logging import getLogger
 
 from django.db.models.signals import post_save
@@ -11,7 +14,7 @@ log = getLogger(__name__)
 
 
 @receiver(post_save, sender=CourseOverview, dispatch_uid="custom_settings.signals.handlers.initialize_course_settings")
-def initialize_course_settings(sender, instance, created, **kwargs):
+def initialize_course_settings(sender, instance, created, **kwargs):  # pylint: disable=unused-argument
     """
     When ever a new course is created
     1: We add a default entry for the given course in the CustomSettings Model

--- a/common/djangoapps/custom_settings/tests/factories.py
+++ b/common/djangoapps/custom_settings/tests/factories.py
@@ -1,3 +1,6 @@
+"""
+All factories for custom settings app models
+"""
 import factory
 from factory.django import DjangoModelFactory
 from faker.providers import internet
@@ -9,6 +12,10 @@ factory.Faker.add_provider(internet)
 
 
 class CustomSettingsFactory(DjangoModelFactory):
+    """
+    Model factory for CustomSettings model
+    """
+
     class Meta(object):
         model = CustomSettings
         django_get_or_create = ('course_short_id',)

--- a/common/djangoapps/custom_settings/tests/test_handlers.py
+++ b/common/djangoapps/custom_settings/tests/test_handlers.py
@@ -1,3 +1,6 @@
+"""
+All unit test for handlers in custom settings app
+"""
 import pytest
 
 from course_modes.models import CourseMode

--- a/common/djangoapps/custom_settings/tests/test_helpers.py
+++ b/common/djangoapps/custom_settings/tests/test_helpers.py
@@ -1,3 +1,7 @@
+"""
+All unit test for helpers in custom settings app
+"""
+# pylint: disable=redefined-outer-name
 from datetime import datetime
 
 import pytest

--- a/common/djangoapps/custom_settings/tests/test_models.py
+++ b/common/djangoapps/custom_settings/tests/test_models.py
@@ -1,3 +1,6 @@
+"""
+All unit test for models in custom settings app
+"""
 import pytest
 
 from .factories import CustomSettingsFactory

--- a/common/djangoapps/custom_settings/tests/test_views.py
+++ b/common/djangoapps/custom_settings/tests/test_views.py
@@ -1,3 +1,6 @@
+"""
+All unit test for views in custom settings app
+"""
 from datetime import datetime
 from json import dumps
 
@@ -16,6 +19,9 @@ from xmodule.modulestore.tests.factories import CourseFactory
 
 
 class CustomSettingsTestCase(PhiluThemeMixin, ModuleStoreTestCase):
+    """
+    Unit tests for custom settings app views
+    """
 
     def setUp(self):
         super(CustomSettingsTestCase, self).setUp()

--- a/common/djangoapps/custom_settings/urls.py
+++ b/common/djangoapps/custom_settings/urls.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.conf.urls import url
-from .views import course_custom_settings
 
+from .views import course_custom_settings
 
 urlpatterns = [
     url(r'^settings/custom/{}$'.format(settings.COURSE_KEY_PATTERN), course_custom_settings, name='custom_settings'),

--- a/common/djangoapps/custom_settings/urls.py
+++ b/common/djangoapps/custom_settings/urls.py
@@ -1,3 +1,6 @@
+"""
+Urls for custom settings app
+"""
 from django.conf import settings
 from django.conf.urls import url
 

--- a/common/djangoapps/custom_settings/views.py
+++ b/common/djangoapps/custom_settings/views.py
@@ -1,3 +1,6 @@
+"""
+All views for custom settings app
+"""
 import json
 import logging
 


### PR DESCRIPTION
### Description

[LP-2273](https://philanthropyu.atlassian.net/browse/LP-2273)

### Notes

- [x] All linting issue fixed, now rating is 10/10
- [x] All unit test for the app are passing
- [x] iSort ran on while app
- [x] All linting issue posted on the story as a comment

Following issue are fixed
```
************* Module edx-platform.common.djangoapps.custom_settings
common/djangoapps/custom_settings/__init__.py:1: [C0111(missing-docstring), ] Missing module docstring
************* Module edx-platform.common.djangoapps.custom_settings.models
common/djangoapps/custom_settings/models.py:1: [C0111(missing-docstring), ] Missing module docstring
common/djangoapps/custom_settings/models.py:29: [W0221(arguments-differ), CustomSettings.save] Parameters differ from overridden 'save' method
************* Module edx-platform.common.djangoapps.custom_settings.apps
common/djangoapps/custom_settings/apps.py:1: [C0111(missing-docstring), ] Missing module docstring
common/djangoapps/custom_settings/apps.py:11: [W0612(unused-variable), CustomSettingsConfig.ready] Unused variable 'custom_settings.signals.handlers'
************* Module edx-platform.common.djangoapps.custom_settings.admin
common/djangoapps/custom_settings/admin.py:1: [C0111(missing-docstring), ] Missing module docstring
************* Module edx-platform.common.djangoapps.custom_settings.urls
common/djangoapps/custom_settings/urls.py:1: [C0111(missing-docstring), ] Missing module docstring
************* Module edx-platform.common.djangoapps.custom_settings.helpers
common/djangoapps/custom_settings/helpers.py:1: [C0111(missing-docstring), ] Missing module docstring
common/djangoapps/custom_settings/helpers.py:2: [C0411(wrong-import-order), ] standard import "from datetime import datetime" should be placed before "import pytz"
************* Module edx-platform.common.djangoapps.custom_settings.views
common/djangoapps/custom_settings/views.py:1: [C0111(missing-docstring), ] Missing module docstring
************* Module edx-platform.common.djangoapps.custom_settings.signals.handlers
common/djangoapps/custom_settings/signals/handlers.py:1: [C0111(missing-docstring), ] Missing module docstring
common/djangoapps/custom_settings/signals/handlers.py:14: [W0613(unused-argument), initialize_course_settings] Unused argument 'sender'
common/djangoapps/custom_settings/signals/handlers.py:14: [W0613(unused-argument), initialize_course_settings] Unused argument 'kwargs'
************* Module edx-platform.common.djangoapps.custom_settings.tests.test_handlers
common/djangoapps/custom_settings/tests/test_handlers.py:1: [C0111(missing-docstring), ] Missing module docstring
************* Module edx-platform.common.djangoapps.custom_settings.tests.factories
common/djangoapps/custom_settings/tests/factories.py:1: [C0111(missing-docstring), ] Missing module docstring
common/djangoapps/custom_settings/tests/factories.py:11: [C0111(missing-docstring), CustomSettingsFactory] Missing class docstring
************* Module edx-platform.common.djangoapps.custom_settings.tests.test_views
common/djangoapps/custom_settings/tests/test_views.py:1: [C0111(missing-docstring), ] Missing module docstring
common/djangoapps/custom_settings/tests/test_views.py:18: [C0111(missing-docstring), CustomSettingsTestCase] Missing class docstring
************* Module edx-platform.common.djangoapps.custom_settings.tests.test_models
common/djangoapps/custom_settings/tests/test_models.py:1: [C0111(missing-docstring), ] Missing module docstring
************* Module edx-platform.common.djangoapps.custom_settings.tests.test_helpers
common/djangoapps/custom_settings/tests/test_helpers.py:1: [C0111(missing-docstring), ] Missing module docstring
common/djangoapps/custom_settings/tests/test_helpers.py:41: [W0621(redefined-outer-name), test_validate_course_open_date_exceptions] Redefining name 'course_open_date_settings_fixture' from outer scope (line 24)
common/djangoapps/custom_settings/tests/test_helpers.py:55: [W0621(redefined-outer-name), test_validate_course_open_date] Redefining name 'course_open_date_settings_fixture' from outer scope (line 24)

-----------------------------------
Your code has been rated at 9.05/10
```