### PR TITLE
 LP-2155 Add is_mini_lesson method to add mini lesson header on course card

### DIFF
--- a/common/djangoapps/custom_settings/models.py
+++ b/common/djangoapps/custom_settings/models.py
@@ -12,7 +12,7 @@ class CustomSettingsManager(models.Manager):
     """
     def is_mini_lesson(self, course_key):
         """
-        This method checks course with course_key is mini lesson or not
+        This method checks course with course_key if it is mini lesson or not
 
         Args:
             course_key (CourseKey, str): Course key

--- a/common/djangoapps/custom_settings/models.py
+++ b/common/djangoapps/custom_settings/models.py
@@ -1,8 +1,27 @@
 import json
 
 from django.db import models
+from opaque_keys.edx.keys import CourseKey
 
 from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
+
+
+class CustomSettingsManager(models.Manager):
+    """
+    Course Custom Settings Manager
+    """
+    def is_mini_lesson(self, course_key):
+        """
+        This method checks course with course_key is mini lesson or not
+
+        Args:
+            course_key (CourseKey, str): Course key
+        Returns:
+            bool: True if course is mini lesson else False
+        """
+        if isinstance(course_key, (str, unicode)):
+            course_key = CourseKey.from_string(course_key)
+        return self.get_queryset().filter(id=course_key, is_mini_lesson=True).exists()
 
 
 class CustomSettings(models.Model):
@@ -19,6 +38,8 @@ class CustomSettings(models.Model):
     seo_tags = models.TextField(null=True, blank=True)
     course_open_date = models.DateTimeField(null=True)
     is_mini_lesson = models.BooleanField(default=False)
+
+    objects = CustomSettingsManager()
 
     class Meta:
         app_label = 'custom_settings'

--- a/openedx/features/course_card/views.py
+++ b/openedx/features/course_card/views.py
@@ -1,13 +1,15 @@
 from datetime import datetime
 
 import pytz
-from course_action_state.models import CourseRerunState
-from philu_overrides.helpers import get_user_current_enrolled_class
-from edxmako.shortcuts import render_to_response
-from openedx.features.course_card.models import CourseCard
 from django.views.decorators.csrf import csrf_exempt
+
+from course_action_state.models import CourseRerunState
+from edxmako.shortcuts import render_to_response
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+from openedx.features.course_card.models import CourseCard
+from philu_overrides.helpers import get_user_current_enrolled_class
 from student.models import CourseEnrollment
+
 from .helpers import get_course_open_date
 
 utc = pytz.UTC
@@ -107,7 +109,3 @@ def get_course_with_link_and_start_date(course, course_rerun_object, request):
 
     course.start_date = None
     return course
-
-
-
-


### PR DESCRIPTION
### Description

[LP-2155](https://philanthropyu.atlassian.net/browse/LP-2155)

[Theme PR](https://github.com/philanthropy-u/philu-edx-theme/pull/1419)

- [x] Add manager for custom settings
- [x] Add is_mini_lesson method in manager to check if course of given course key is mini lesson or no 