### PR TITLE
LP-2254 Postfix remove pytest-mock from base.txt

### DIFF
--- a/requirements/philu/base.txt
+++ b/requirements/philu/base.txt
@@ -12,4 +12,3 @@ img2pdf==0.2.4
 -e git+https://github.com/philanthropy-u/edx-notifications.git@9c602923d0e8a7b512a52bc4d0df5c7043286386#egg=edx-notifications
 git+https://github.com/philanthropy-u/openedx-scorm-xblock.git@master#egg=openedx-scorm-xblock
 django-multiselectfield==0.1.12
-pytest-mock==2.0.0


### PR DESCRIPTION
### Description

[LP-2254](https://philanthropyu.atlassian.net/browse/LP-2254)

Removing the new package `pytest-mock==2.0.0` introduced in base.txt. After the package was introduced, it has probably updated other packages, due to which deployment is failing on dev server.