### PR TITLE
 LP-2400 Fixing ORA site configuration variable issue

### DIFF
--- a/openedx/features/philu_utils/sites.py
+++ b/openedx/features/philu_utils/sites.py
@@ -1,0 +1,23 @@
+"""
+All utilities for Django sites
+"""
+from logging import getLogger
+
+from django.contrib.sites.models import Site
+
+log = getLogger(__name__)
+
+
+def get_site(site_id):
+    """
+    Get site object from site id
+    Args:
+        site_id (int): the id of site
+
+    Returns:
+        site: The site object otherwise None
+    """
+    try:
+        return Site.objects.get(id=site_id)
+    except Site.DoesNotExist:
+        log.error('Site with id {id}, does not exists'.format(id=site_id))

--- a/openedx/features/philu_utils/tests/test_sites.py
+++ b/openedx/features/philu_utils/tests/test_sites.py
@@ -1,0 +1,28 @@
+"""
+All the tests for utilities of Django sites
+"""
+import pytest
+from mock import patch
+
+from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory
+from openedx.features.philu_utils.sites import get_site
+
+
+@pytest.mark.django_db
+def test_get_site_successfully():
+    """
+    Assert that site exists and returned successfully
+    """
+    site = SiteFactory()
+    assert site == get_site(site.id)
+
+
+@pytest.mark.django_db
+@patch('openedx.features.philu_utils.sites.log.error')
+def test_get_site_site_not_found(mock_log_error):
+    """
+    Assert that site does not exists
+    """
+    site = get_site(200)
+    assert site is None
+    assert mock_log_error.called_once


### PR DESCRIPTION
### Description

[LP-2400](https://philanthropyu.atlassian.net/browse/LP-2400)

Now command will take `--site-id={site_id}`, an extra param to get configuration from the site. If `site_id` is not provided or site for provided id does not exists then ORA days to wait constantly will default to 3 days.

### Notes
- Unit tets updated
- All unit test passing
- Pylint score 10/10
- iSort ran on files