### PR TITLE
LP-1936 Behavior of Reset Password Option is not Consistent

### DIFF
--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -940,6 +940,15 @@ def password_reset_confirm_wrapper(request, uidb36=None, token=None):
                 )
                 response.context_data['err_msg'] = _('Error in resetting your password. Please try again.')
                 return response
+        elif response.status_code == 302:
+            MandrillClient().send_mail(
+                MandrillClient.PASSWORD_RESET_COMPLETE,
+                user.email,
+                {
+                    'first_name': user.first_name,
+                    'signin_link': settings.LMS_ROOT_URL + '/login'
+                }
+            )
 
         # get the updated user
         updated_user = User.objects.get(id=uid_int)

--- a/common/lib/mandrill_client/client.py
+++ b/common/lib/mandrill_client/client.py
@@ -16,6 +16,7 @@ class MandrillClient(object):
     """
     ACUMEN_DATA_TEMPLATE = 'acumen-data'
     PASSWORD_RESET_TEMPLATE = 'template-60'
+    PASSWORD_RESET_COMPLETE = 'reset-password-complete'
     USER_ACCOUNT_ACTIVATION_TEMPLATE = 'template-61'
     ORG_ADMIN_ACTIVATION_TEMPLATE = 'org-admin-identified'
     ORG_ADMIN_CHANGE_TEMPLATE = 'org-admin-change'


### PR DESCRIPTION
Behavior of Reset Password Option is not Consistent on Reset Password page

### Description

[LP-1936](https://philanthropyu.atlassian.net/browse/LP-1936)

Add password change email success email on successfully changing password.