### PR TITLE
lp-2539 Fix isort skip file issue

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -97,7 +97,7 @@ jobs:
         id: isort-report
         continue-on-error: true
         run: |
-          isort ${{ env.GIT_DIFF }} -c 2>&1 | tee report_isort.txt
+          isort -ns ${{ env.GIT_DIFF }} -c 2>&1 | tee report_isort.txt
 
           body=$(cat report_isort.txt)
           body="${body//'%'/'%25'}"


### PR DESCRIPTION
isort default behavior is to skip __init__.py file. In recent PRs regarding linting we have been adding the doc string in __init__.py file that lead to isort command to generate message "Skipped 1 file". Have added a -ns (no-skip) flag to the command.