### PR TITLE
LP-1744 Removing pytest mock package from base requirements

### DIFF
--- a/requirements/philu/base.txt
+++ b/requirements/philu/base.txt
@@ -12,4 +12,3 @@ img2pdf==0.2.4
 -e git+https://github.com/philanthropy-u/edx-notifications.git@c1d538a757f03ea048301f7035713510cc5a1b0d#egg=edx-notifications
 git+https://github.com/philanthropy-u/openedx-scorm-xblock.git@master#egg=openedx-scorm-xblock
 django-multiselectfield==0.1.12
-pytest-mock==2.0.0


### PR DESCRIPTION
### Description

[LP-1744](https://philanthropyu.atlassian.net/browse/LP-1744)

Note:

Removing pytest mock package from base requirements as it conflicts with other packages. We have this package installed only for testing. So tests will still work.