### PR TITLE
LP-2272 Fixing bug in send_ondemand_reminder_emails

### DIFF
--- a/common/djangoapps/philu_commands/management/commands/send_ondemand_reminder_emails.py
+++ b/common/djangoapps/philu_commands/management/commands/send_ondemand_reminder_emails.py
@@ -95,7 +95,7 @@ class Command(BaseCommand):
 
                 latest_submission = response_submissions.first()
 
-                if response_submissions:
+                if not response_submissions.exists():
                     if has_inactivity_threshold_reached(enrollment.created.date(), today):
                         send_reminder_email(user, course, course_deadline)
                     continue


### PR DESCRIPTION
### Description

[LP-2272](https://philanthropyu.atlassian.net/browse/LP-2272)

**Error log**

```
14:34:39 2021-04-20 05:34:39,462 INFO 7618 [philu_commands.management.commands.send_ondemand_reminder_emails] send_ondemand_reminder_emails.py:70 - Multiple Anonymous Ids for ranawaqar1
14:34:39 2021-04-20 05:34:39,464 INFO 7618 [philu_commands.management.commands.send_ondemand_reminder_emails] send_ondemand_reminder_emails.py:70 - Multiple Anonymous Ids for kavywodaqe
14:34:39 2021-04-20 05:34:39,467 INFO 7618 [lms.djangoapps.onboarding.helpers] helpers.py:8065 - No email preferences found for zhb12 hence considered True
14:34:39 2021-04-20 05:34:39,473 WARNING 7618 [py.warnings] locator.py:357 - /edx/app/edxapp/edx-platform/common/djangoapps/philu_commands/management/commands/send_ondemand_reminder_emails.py:87: DeprecationWarning: to_deprecated_string is deprecated! Use unicode(key) instead.
14:34:39   student_item__course_id=course.id.to_deprecated_string()).order_by('-created_at')
14:34:39 
14:34:39 Traceback (most recent call last):
14:34:39   File "/edx/app/edxapp/edx-platform/manage.py", line 123, in <module>
14:34:39     execute_from_command_line([sys.argv[0]] + django_args)
14:34:39   File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 364, in execute_from_command_line
14:34:39     utility.execute()
14:34:39   File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 356, in execute
14:34:39     self.fetch_command(subcommand).run_from_argv(self.argv)
14:34:39   File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/management/base.py", line 283, in run_from_argv
14:34:39     self.execute(*args, **cmd_options)
14:34:39   File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/management/base.py", line 330, in execute
14:34:39     output = self.handle(*args, **options)
14:34:39   File "/edx/app/edxapp/edx-platform/common/djangoapps/philu_commands/management/commands/send_ondemand_reminder_emails.py", line 108, in handle
14:34:39     if has_inactivity_threshold_reached(latest_submission.created_at.date(), today):
14:34:39 AttributeError: 'NoneType' object has no attribute 'created_at'
```